### PR TITLE
Java optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ warnings_are_errors: true
 #sudo: required
 cache: packages
 
+env:
+  - GCAMDATA_USE_JAVA=TRUE
+
 r_github_packages:
   - jimhester/covr
   - krlmlr/mockr

--- a/R/onload.R
+++ b/R/onload.R
@@ -1,0 +1,13 @@
+# onload.R
+
+.onLoad <- function(libname, pkgname) {
+  op <- options()
+  op.gcamdata <- list(
+    gcamdata.use_java = FALSE
+  )
+  toset <- !(names(op.gcamdata) %in% names(op))
+  if (any(toset)) {
+    options(op.gcamdata[toset])
+  }
+  invisible()
+}

--- a/R/onload.R
+++ b/R/onload.R
@@ -3,7 +3,7 @@
 .onLoad <- function(libname, pkgname) {
   op <- options()
   op.gcamdata <- list(
-    gcamdata.use_java = FALSE
+    gcamdata.use_java = isTRUE(as.logical(Sys.getenv("GCAMDATA_USE_JAVA")))
   )
   toset <- !(names(op.gcamdata) %in% names(op))
   if (any(toset)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -295,9 +295,9 @@ chunk_outputs <- function(chunks = find_chunks()$name) {
 #' to add the data to convert and finally ending with \code{\link{run_xml_conversion}}
 #' to run the conversion.
 #'
-#' @param xml_file The name to save the XML file to.
+#' @param xml_file The name to save the XML file to
 #' @param mi_header The model interface "header".  This will default to the one
-#' included in this package.
+#' included in this package
 #' @return A "data structure" to hold the various parts needed to run the model
 #' interface CSV to XML conversion.
 #' @export
@@ -317,12 +317,13 @@ create_xml <- function(xml_file, mi_header = NULL) {
 #' tibble.  This method is meant to be included in a pipeline between calls of
 #' \code{\link{create_xml}} and \code{\link{run_xml_conversion}}.
 #'
-#' @param dot The current state of the pipeline started from \code{create_xml}.
-#' @param data The tibble of data to add to the conversion.
+#' @param dot The current state of the pipeline started from \code{create_xml}
+#' @param data The tibble of data to add to the conversion
 #' @param header The header tag to can be looked up in the header file to
-#' convert \code{data}.
+#' convert \code{data}
 #' @return A "data structure" to hold the various parts needed to run the model
 #' interface CSV to XML conversion.
+#' @author PP March 2017
 #' @export
 add_xml_data <- function(dot, data, header) {
   curr_table <- list(data = data, header = header)
@@ -373,15 +374,16 @@ make_run_xml_conversion <- function() {
 #' run_xml_conversion
 #'
 #' Run the CSV to XML conversion using the model interface tool.  This method
-#' is should be the final call in a pipeline started with \code{\link{create_xml}}
+#' should be the final call in a pipeline started with \code{\link{create_xml}}
 #' and one or more calls to \code{\link{add_xml_data}}.
 #'
-#' Not that this method relies on Java to run the conversion.  To avoid errros for
+#' Not that this method relies on Java to run the conversion.  To avoid errors for
 #' users who do not have Java installed it will check the global option
 #' \code{gcamdata.use_java} before attempting to run the conversion.  If the flag
 #' is set to \code{FALSE} a warning will be issued and the conversion skipped.
 #' To enable the use of Java a user can set \code{options(gcamdata.use_java=TRUE)}
 #'
-#' @param dot The current state of the pipeline started from \code{create_xml}.
+#' @param dot The current state of the pipeline started from \code{create_xml}
+#' @author PP March 2017
 #' @export
 run_xml_conversion <- make_run_xml_conversion()

--- a/man/add_xml_data.Rd
+++ b/man/add_xml_data.Rd
@@ -7,12 +7,12 @@
 add_xml_data(dot, data, header)
 }
 \arguments{
-\item{dot}{The current state of the pipeline started from \code{create_xml}.}
+\item{dot}{The current state of the pipeline started from \code{create_xml}}
 
-\item{data}{The tibble of data to add to the conversion.}
+\item{data}{The tibble of data to add to the conversion}
 
 \item{header}{The header tag to can be looked up in the header file to
-convert \code{data}.}
+convert \code{data}}
 }
 \value{
 A "data structure" to hold the various parts needed to run the model
@@ -23,5 +23,8 @@ Add a table to include for conversion to XML.  We need the tibble to convert
 and a header tag which can be looked up in the header file to convert the
 tibble.  This method is meant to be included in a pipeline between calls of
 \code{\link{create_xml}} and \code{\link{run_xml_conversion}}.
+}
+\author{
+PP March 2017
 }
 

--- a/man/create_xml.Rd
+++ b/man/create_xml.Rd
@@ -7,10 +7,10 @@
 create_xml(xml_file, mi_header = NULL)
 }
 \arguments{
-\item{xml_file}{The name to save the XML file to.}
+\item{xml_file}{The name to save the XML file to}
 
 \item{mi_header}{The model interface "header".  This will default to the one
-included in this package.}
+included in this package}
 }
 \value{
 A "data structure" to hold the various parts needed to run the model

--- a/man/run_xml_conversion.Rd
+++ b/man/run_xml_conversion.Rd
@@ -7,17 +7,21 @@
 run_xml_conversion(dot)
 }
 \arguments{
-\item{dot}{The current state of the pipeline started from \code{create_xml}.}
+\item{dot}{The current state of the pipeline started from \code{create_xml}}
 }
 \description{
 Run the CSV to XML conversion using the model interface tool.  This method
-is should be the final call in a pipeline started with \code{\link{create_xml}}
+should be the final call in a pipeline started with \code{\link{create_xml}}
 and one or more calls to \code{\link{add_xml_data}}.
 }
 \details{
-Not that this method relies on Java to run the conversion.  To avoid errros for
+Not that this method relies on Java to run the conversion.  To avoid errors for
 users who do not have Java installed it will check the global option
 \code{gcamdata.use_java} before attempting to run the conversion.  If the flag
 is set to \code{FALSE} a warning will be issued and the conversion skipped.
 To enable the use of Java a user can set \code{options(gcamdata.use_java=TRUE)}
 }
+\author{
+PP March 2017
+}
+

--- a/man/run_xml_conversion.Rd
+++ b/man/run_xml_conversion.Rd
@@ -14,4 +14,10 @@ Run the CSV to XML conversion using the model interface tool.  This method
 is should be the final call in a pipeline started with \code{\link{create_xml}}
 and one or more calls to \code{\link{add_xml_data}}.
 }
-
+\details{
+Not that this method relies on Java to run the conversion.  To avoid errros for
+users who do not have Java installed it will check the global option
+\code{gcamdata.use_java} before attempting to run the conversion.  If the flag
+is set to \code{FALSE} a warning will be issued and the conversion skipped.
+To enable the use of Java a user can set \code{options(gcamdata.use_java=TRUE)}
+}

--- a/tests/testthat/test_xml_conv_utils.R
+++ b/tests/testthat/test_xml_conv_utils.R
@@ -9,21 +9,30 @@ test_that("default MI header exists in the package", {
 })
 
 test_that("bogus MI header causes error", {
-  # TODO: need to find a way to get messages from Java
+  if(!isTRUE(getOption("gcamdata.use_java"))) {
+    skip("Skipping test as global option gcamdata.use_java is not TRUE")
+  }
+  # TODO: need to find a way to get messages from Java (issue )
   # conv_test <- create_xml("test.xml", "bogus.txt")
   #
   # expect_message(run_xml_conversion(conv_test), regex="java.io.FileNotFoundException: bogus.txt", all=F)
 })
 
 test_that("converting without adding data causes error", {
-  # TODO: need to find a way to get messages from Java
+  if(!isTRUE(getOption("gcamdata.use_java"))) {
+    skip("Skipping test as global option gcamdata.use_java is not TRUE")
+  }
+  # TODO: need to find a way to get messages from Java (See issue #102)
   # conv_test <- create_xml("test.xml")
   #
   # expect_message(run_xml_conversion(conv_test), regex="java.lang.NullPointerException", all=F)
 })
 
 test_that("converting bogus data causes error", {
-  # TODO: need to find a way to get messages from Java
+  if(!isTRUE(getOption("gcamdata.use_java"))) {
+    skip("Skipping test as global option gcamdata.use_java is not TRUE")
+  }
+  # TODO: need to find a way to get messages from Java (See issue #102)
   # create_xml("test.xml") %>%
   #   add_xml_data("bogus", "InterestRate") -> conv_test
   #
@@ -31,6 +40,9 @@ test_that("converting bogus data causes error", {
 })
 
 test_that("can convert single table", {
+  if(!isTRUE(getOption("gcamdata.use_java"))) {
+    skip("Skipping test as global option gcamdata.use_java is not TRUE")
+  }
   test_fn <- "test.xml"
   data1 <- data.frame(region = "USA", interest.rate = "1.0")
   create_xml(test_fn) %>%
@@ -48,6 +60,9 @@ test_that("can convert single table", {
 })
 
 test_that("can convert multiple table", {
+  if(!isTRUE(getOption("gcamdata.use_java"))) {
+    skip("Skipping test as global option gcamdata.use_java is not TRUE")
+  }
   test_fn <- "test.xml"
   data1 <- data.frame(region = "USA", interest.rate = "1.0")
   data2 <- data.frame(region = "USA", PrimaryFuel = "shoes", PrimaryFuelCO2Coef = 0.007653)
@@ -67,6 +82,9 @@ test_that("can convert multiple table", {
 })
 
 test_that("get warning for missing header", {
+  if(!isTRUE(getOption("gcamdata.use_java"))) {
+    skip("Skipping test as global option gcamdata.use_java is not TRUE")
+  }
   test_fn <- "test.xml"
   data1 <- data.frame(region = "USA", interest.rate = "1.0")
   data2 <- data.frame(region = "USA", PrimaryFuel = "shoes", PrimaryFuelCO2Coef = 0.007653)
@@ -74,7 +92,7 @@ test_that("get warning for missing header", {
     add_xml_data(data1, "InterestRate") %>%
     add_xml_data(data2, "Will_Not_Find") ->
     conv_test
-  # TODO: need to find a way to get messages from Java
+  # TODO: need to find a way to get messages from Java (See issue #102)
   #expect_message(run_xml_conversion(conv_test), regex = "Warning: skipping table: Will_Not_Find!", all = FALSE)
   run_xml_conversion(conv_test)
 


### PR DESCRIPTION
Adds a global option gcamdata.use_java (default to FALSE) that controls if `run_xml_conversion` and any of the tests that rely on it are actually run so they can be safely skipped if a user does not have Java installed.

This resolves #103  