### PR TITLE
Fix behavior of left_join_keep_first_only using named 'by' vector.

### DIFF
--- a/R/pipeline-helpers.R
+++ b/R/pipeline-helpers.R
@@ -61,7 +61,9 @@ left_join_error_no_match <- function(d, ...) {
 left_join_keep_first_only <- function(x, y, by) {
     ## Our strategy is to use "distinct" to filter y to a single element for
     ## each match category, then join that to x.
-    do.call(distinct_, c(list(y), as.list(by), list(.keep_all = TRUE))) %>%
+    ll <- as.list(by)
+    names(ll) <- NULL
+    do.call(distinct_, c(list(y), ll, list(.keep_all = TRUE))) %>%
       left_join(x, ., by = by)
 }
 

--- a/tests/testthat/test_pipeline-helpers.R
+++ b/tests/testthat/test_pipeline-helpers.R
@@ -109,4 +109,9 @@ test_that("left_join_keep_first_only works", {
   expect_equal(r4,
                mutate(x2, coef = c(1, 2, 4, 3)))
 
+  ## test named vector to rename columns
+  y2 <- rename(y, country = iso)
+  expect_silent(r5 <- left_join_keep_first_only(x2, y2, by = c(iso = 'country', 'year')))
+  expect_equal(r4, r5)
+
 })


### PR DESCRIPTION
Fixes #316 
