### PR TITLE
Fix bad interaction between dplyr NSE and data frame $ indexing.

### DIFF
--- a/R/zchunk_L242.Bld_Inc_Elas_scenarios.R
+++ b/R/zchunk_L242.Bld_Inc_Elas_scenarios.R
@@ -53,7 +53,7 @@ module_socioeconomics_L242.Bld_Inc_Elas_scenarios <- function(command, ...) {
                                         xout = pcgdp_90thousUSD,
                                         # Rule 2 means that data outside of the interval of input
                                         # data will be assigned the cloest data extreme
-                                        rule = 2)$y %>% round(3),
+                                        rule = 2)[['y']] %>% round(3),
              energy.final.demand = "building") %>%
       select(scenario, region, energy.final.demand, year, income.elasticity) %>%
       arrange(year)

--- a/R/zchunk_L252.Trn_Inc_Elas_scenarios.R
+++ b/R/zchunk_L252.Trn_Inc_Elas_scenarios.R
@@ -48,7 +48,7 @@ module_socioeconomics_L252.Trn_Inc_Elas_scenarios <- function(command, ...) {
       mutate(income.elasticity = approx(x = A52.inc_elas$pcgdp_90thousUSD, y = A52.inc_elas$inc_elas,
                                         # Rule 2 means that data outside of the interval of input
                                         # data will be assigned the closest data extreme
-                                        xout = pcgdp_90thousUSD, rule = 2 )$y,
+                                        xout = pcgdp_90thousUSD, rule = 2 )[['y']],
              energy.final.demand = "transportation") %>%
       # Add in region names
       left_join_error_no_match(GCAM_region_names, by = "GCAM_region_ID") %>%


### PR DESCRIPTION
Apparently, whether this is a bug or not depends on exactly what package versions you have installed.  I'd say the best practice is to avoid using `$` in arguments to dplyr functions that use NSE.
