### PR TITLE
Add travis_wait to the R CMD check step of the CI process.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 
 language: r
 warnings_are_errors: true
-#sudo: required
 cache: packages
 
 env:
@@ -11,5 +10,10 @@ env:
 r_github_packages:
   - jimhester/covr
   - krlmlr/mockr
+
+script:
+  - R CMD build .
+  - travis_wait R CMD check *.tar.gz
+
 after_success:
   - travis_wait Rscript coverage.R


### PR DESCRIPTION
This should prevent us from timing out while running the package tests.

As with the after_success script, the timeout defaults to 20 minutes, but can be increased by adding an additional argument to travis_wait (e.g. `travis_wait 30 R CMD check *.tar.gz`)
