### PR TITLE
Remove precursor warning messages

### DIFF
--- a/R/zchunk_LA101.en_bal_IEA.R
+++ b/R/zchunk_LA101.en_bal_IEA.R
@@ -56,19 +56,15 @@ module_energy_LA101.en_bal_IEA <- function(command, ...) {
       # Proprietary IEA energy data are not available, so used saved outputs
       warning_comment <- "** PRE-BUILT; RAW IEA DATA NOT AVAILABLE **"
       get_data(all_data, "energy/prebuilt_data/L101.en_bal_EJ_R_Si_Fi_Yh_full") %>%
-        add_precursors("energy/prebuilt_data/L101.en_bal_EJ_R_Si_Fi_Yh_full") %>%
         add_comments(warning_comment) ->
         L101.en_bal_EJ_R_Si_Fi_Yh_full
       get_data(all_data, "energy/prebuilt_data/L101.en_bal_EJ_ctry_Si_Fi_Yh_full") %>%
-        add_precursors("energy/prebuilt_data/L101.en_bal_EJ_ctry_Si_Fi_Yh_full") %>%
         add_comments(warning_comment) ->
         L101.en_bal_EJ_ctry_Si_Fi_Yh_full
       get_data(all_data, "energy/prebuilt_data/L101.in_EJ_ctry_trn_Fi_Yh") %>%
-        add_precursors("energy/prebuilt_data/L101.in_EJ_ctry_trn_Fi_Yh") %>%
         add_comments(warning_comment) ->
         L101.in_EJ_ctry_trn_Fi_Yh
       get_data(all_data, "energy/prebuilt_data/L101.in_EJ_ctry_bld_Fi_Yh") %>%
-        add_precursors("energy/prebuilt_data/L101.in_EJ_ctry_bld_Fi_Yh") %>%
         add_comments(warning_comment) ->
         L101.in_EJ_ctry_bld_Fi_Yh
 
@@ -251,7 +247,9 @@ module_energy_LA101.en_bal_IEA <- function(command, ...) {
       add_comments("L101.en_bal_EJ_R_Si_Fi_Yh_full includes energy balances and assumptions for total primary energy supply (TPES)") %>%
       add_legacy_name("L101.en_bal_EJ_R_Si_Fi_Yh_full") %>%
       add_precursors("common/iso_GCAM_regID", "energy/A_regions", "energy/IEA_flow_sector", "energy/IEA_product_fuel",
-                     "energy/IEA_sector_fuel_modifications", "energy/enduse_fuel_aggregation", "L100.IEA_en_bal_ctry_hist") %>%
+                     "energy/IEA_sector_fuel_modifications", "energy/enduse_fuel_aggregation",
+                     "L100.IEA_en_bal_ctry_hist",
+                     "energy/prebuilt_data/L101.en_bal_EJ_R_Si_Fi_Yh_full") %>%
       add_flags(FLAG_LONG_YEAR_FORM, FLAG_NO_XYEAR) ->
       L101.en_bal_EJ_R_Si_Fi_Yh_full
 
@@ -260,6 +258,7 @@ module_energy_LA101.en_bal_IEA <- function(command, ...) {
       add_comments("For country-level comparisons, keep the iso and aggregate all sectors and fuels. It also includes TPES by country") %>%
       add_legacy_name("L101.en_bal_EJ_ctry_Si_Fi_Yh_full") %>%
       same_precursors_as(L101.en_bal_EJ_R_Si_Fi_Yh_full) %>%
+      add_precursors("energy/prebuilt_data/L101.en_bal_EJ_ctry_Si_Fi_Yh_full") %>%
       add_flags(FLAG_LONG_YEAR_FORM, FLAG_NO_XYEAR, FLAG_SUM_TEST) ->
       L101.en_bal_EJ_ctry_Si_Fi_Yh_full
 
@@ -268,6 +267,7 @@ module_energy_LA101.en_bal_IEA <- function(command, ...) {
       add_comments("Consumption of energy by the transport sector by fuel and historical year. Aggregated by fuel and country") %>%
       add_legacy_name("L101.in_EJ_ctry_trn_Fi_Yh") %>%
       same_precursors_as(L101.en_bal_EJ_R_Si_Fi_Yh_full) %>%
+      add_precursors("energy/prebuilt_data/L101.in_EJ_ctry_trn_Fi_Yh") %>%
       add_flags(FLAG_LONG_YEAR_FORM, FLAG_NO_XYEAR) ->
       L101.in_EJ_ctry_trn_Fi_Yh
 
@@ -276,6 +276,7 @@ module_energy_LA101.en_bal_IEA <- function(command, ...) {
       add_comments("Consumption of energy by the building sector by fuel and historical year. Aggregated by fuel and country") %>%
       add_legacy_name("L101.in_EJ_ctry_bld_Fi_Yh") %>%
       same_precursors_as(L101.en_bal_EJ_R_Si_Fi_Yh_full) %>%
+      add_precursors("energy/prebuilt_data/L101.in_EJ_ctry_bld_Fi_Yh") %>%
       add_flags(FLAG_LONG_YEAR_FORM, FLAG_NO_XYEAR) ->
       L101.in_EJ_ctry_bld_Fi_Yh
 

--- a/R/zchunk_LA118.hydro.R
+++ b/R/zchunk_LA118.hydro.R
@@ -38,8 +38,7 @@ module_energy_LA118.hydro <- function(command, ...) {
     # pre-built output dataset and exit.
     if(is.null(L100.IEA_en_bal_ctry_hist)) {
       get_data(all_data, "energy/prebuilt_data/L118.out_EJ_R_elec_hydro_Yfut") %>%
-        add_comments("** PRE-BUILT; RAW IEA DATA NOT AVAILABLE **") %>%
-        add_precursors("energy/prebuilt_data/L118.out_EJ_R_elec_hydro_Yfut") ->
+        add_comments("** PRE-BUILT; RAW IEA DATA NOT AVAILABLE **") ->
         L118.out_EJ_R_elec_hydro_Yfut
     } else {
       L100.IEA_en_bal_ctry_hist %>%
@@ -230,7 +229,8 @@ module_energy_LA118.hydro <- function(command, ...) {
                    multiplied by its share in the region, and added to the base-year ouput") %>%
       add_legacy_name("L118.out_EJ_R_elec_hydro_Yfut") %>%
       add_precursors("common/iso_GCAM_regID", "energy/Hydropower_potential",
-                     "L100.IEA_en_bal_ctry_hist", "energy/A18.hydro_output") %>%
+                     "L100.IEA_en_bal_ctry_hist", "energy/A18.hydro_output",
+                     "energy/prebuilt_data/L118.out_EJ_R_elec_hydro_Yfut") %>%
       add_flags(FLAG_LONG_YEAR_FORM, FLAG_NO_XYEAR) ->
       L118.out_EJ_R_elec_hydro_Yfut
 

--- a/R/zchunk_LA121.oil.R
+++ b/R/zchunk_LA121.oil.R
@@ -59,15 +59,12 @@ module_energy_LA121.oil <- function(command, ...) {
       # Proprietary IEA energy data are not available, so used saved outputs
       warning_comment <- "** PRE-BUILT; RAW IEA DATA NOT AVAILABLE **"
       get_data(all_data, "energy/prebuilt_data/L121.in_EJ_R_unoil_F_Yh") %>%
-        add_precursors("energy/prebuilt_data/L121.in_EJ_R_unoil_F_Yh") %>%
         add_comments(warning_comment) ->
         L121.in_EJ_R_unoil_F_Yh
       get_data(all_data, "energy/prebuilt_data/L121.in_EJ_R_TPES_crude_Yh") %>%
-        add_precursors("energy/prebuilt_data/L121.in_EJ_R_TPES_crude_Yh") %>%
         add_comments(warning_comment) ->
         L121.in_EJ_R_TPES_crude_Yh
       get_data(all_data, "energy/prebuilt_data/L121.in_EJ_R_TPES_unoil_Yh") %>%
-        add_precursors("energy/prebuilt_data/L121.in_EJ_R_TPES_unoil_Yh") %>%
         add_comments(warning_comment) ->
         L121.in_EJ_R_TPES_unoil_Yh
 
@@ -183,7 +180,9 @@ module_energy_LA121.oil <- function(command, ...) {
       add_units("EJ") %>%
       add_comments("Inputs to unconventional oil production calculated by multiplying production data by IO coef") %>%
       add_legacy_name("L121.in_EJ_R_unoil_F_Yh") %>%
-      add_precursors("temp-data-inject/L111.Prod_EJ_R_F_Yh", "energy/A21.globaltech_coef", "energy/calibrated_techs") %>%
+      add_precursors("temp-data-inject/L111.Prod_EJ_R_F_Yh", "energy/A21.globaltech_coef",
+                     "energy/calibrated_techs",
+                     "energy/prebuilt_data/L121.in_EJ_R_unoil_F_Yh") %>%
       add_flags(FLAG_LONG_YEAR_FORM, FLAG_NO_XYEAR) ->
       L121.in_EJ_R_unoil_F_Yh
 
@@ -193,7 +192,7 @@ module_energy_LA121.oil <- function(command, ...) {
       add_comments("Unconventional oil subtracted from total primary energy supply of liquids") %>%
       add_comments("to determine crude oil supply") %>%
       add_legacy_name("L121.in_EJ_R_TPES_crude_Yh") %>%
-      add_precursors("L1011.en_bal_EJ_R_Si_Fi_Yh") %>%
+      add_precursors("L1011.en_bal_EJ_R_Si_Fi_Yh", "energy/prebuilt_data/L121.in_EJ_R_TPES_crude_Yh") %>%
       add_flags(FLAG_LONG_YEAR_FORM, FLAG_NO_XYEAR) ->
       L121.in_EJ_R_TPES_crude_Yh
 
@@ -202,7 +201,9 @@ module_energy_LA121.oil <- function(command, ...) {
       add_units("EJ") %>%
       add_comments("Unconventional oil production shared out to GCAM regions") %>%
       add_legacy_name("L121.in_EJ_R_TPES_unoil_Yh") %>%
-      add_precursors("temp-data-inject/L111.Prod_EJ_R_F_Yh", "energy/A21.unoil_demandshares", "L100.IEA_en_bal_ctry_hist", "common/iso_GCAM_regID", "energy/mappings/IEA_product_rsrc") %>%
+      add_precursors("temp-data-inject/L111.Prod_EJ_R_F_Yh", "energy/A21.unoil_demandshares", "L100.IEA_en_bal_ctry_hist", "common/iso_GCAM_regID",
+                     "energy/mappings/IEA_product_rsrc",
+                     "energy/prebuilt_data/L121.in_EJ_R_TPES_unoil_Yh") %>%
       add_flags(FLAG_LONG_YEAR_FORM, FLAG_NO_XYEAR) ->
       L121.in_EJ_R_TPES_unoil_Yh
 


### PR DESCRIPTION
The chunks that may (or may not, depending on IEA data being present)
prebuilt outputs now always include these prebuilts as precursors. This
eliminates the red warning messages during a driver run, messages that
might obscure/confuse.