### PR TITLE
Fix inadvertent SSP3/5 that should have been gSSP3/5 in bld and trn scio xml.

### DIFF
--- a/R/zchunk_batch_bld_agg_xml.R
+++ b/R/zchunk_batch_bld_agg_xml.R
@@ -58,15 +58,15 @@ module_socio_batch_bld_agg_xml <- function(command, ...) {
       add_xml_data(L242.IncomeElasticity_bld_gSSP2, "IncomeElasticity") %>%
       add_precursors("L242.IncomeElasticity_bld_gSSP2") ->
       bld_agg_gSSP2.xml
-    create_xml("bld_agg_SSP3.xml") %>%
-      add_xml_data(L242.IncomeElasticity_bld_SSP3, "IncomeElasticity") %>%
+    create_xml("bld_agg_gSSP3.xml") %>%
+      add_xml_data(L242.IncomeElasticity_bld_gSSP3, "IncomeElasticity") %>%
       add_precursors("L242.IncomeElasticity_bld_gSSP3") ->
       bld_agg_gSSP3.xml
     create_xml("bld_agg_gSSP4.xml") %>%
       add_xml_data(L242.IncomeElasticity_bld_gSSP4, "IncomeElasticity") %>%
       add_precursors("L242.IncomeElasticity_bld_gSSP4") ->
       bld_agg_gSSP4.xml
-    create_xml("bld_agg_SSP5.xml") %>%
+    create_xml("bld_agg_gSSP5.xml") %>%
       add_xml_data(L242.IncomeElasticity_bld_gSSP5, "IncomeElasticity") %>%
       add_precursors("L242.IncomeElasticity_bld_gSSP5") ->
       bld_agg_gSSP5.xml

--- a/R/zchunk_batch_trn_agg_xml.R
+++ b/R/zchunk_batch_trn_agg_xml.R
@@ -58,7 +58,7 @@ module_socio_batch_trn_agg_xml <- function(command, ...) {
       add_xml_data(L252.IncomeElasticity_trn_gSSP2, "IncomeElasticity") %>%
       add_precursors("L252.IncomeElasticity_trn_gSSP2") ->
       trn_agg_gSSP2.xml
-    create_xml("trn_agg_SSP3.xml") %>%
+    create_xml("trn_agg_gSSP3.xml") %>%
       add_xml_data(L252.IncomeElasticity_trn_gSSP3, "IncomeElasticity") %>%
       add_precursors("L252.IncomeElasticity_trn_gSSP3") ->
       trn_agg_gSSP3.xml
@@ -66,7 +66,7 @@ module_socio_batch_trn_agg_xml <- function(command, ...) {
       add_xml_data(L252.IncomeElasticity_trn_gSSP4, "IncomeElasticity") %>%
       add_precursors("L252.IncomeElasticity_trn_gSSP4") ->
       trn_agg_gSSP4.xml
-    create_xml("trn_agg_SSP5.xml") %>%
+    create_xml("trn_agg_gSSP5.xml") %>%
       add_xml_data(L252.IncomeElasticity_trn_gSSP5, "IncomeElasticity") %>%
       add_precursors("L252.IncomeElasticity_trn_gSSP5") ->
       trn_agg_gSSP5.xml


### PR DESCRIPTION
This fixes some of the missing XML files noted in #620, still no GCAM3 inputs files.  Was that a conscious decision to leave out?

Perhaps the bld / trn socioeconomic files should have been implemented in a loop which could have avoided the inadvertent SSP instead gSSP bug.  @d3y419 can clean that up if he so chooses.