### PR TITLE
Revert to using the deprecated nesting_ for dplyr 0.7

### DIFF
--- a/R/module-helpers.R
+++ b/R/module-helpers.R
@@ -423,9 +423,9 @@ fill_exp_decay_extrapolate <- function(d, out_years) {
       complete(tidyr::nesting_(select(., -year, -value)), year = union(year, out_years)) ->
       d
   } else {
-    nesting_vars <- rlang::syms(names(d)[!(names(d) %in% c("year", "value"))])
+    nesting_vars <- paste0('`', names(d)[!(names(d) %in% c("year", "value"))], '`')
     d %>%
-      complete(tidyr::nesting(!!!nesting_vars), year = union(year, out_years)) ->
+      complete(tidyr::nesting_(nesting_vars), year = union(year, out_years)) ->
       d
   }
   d %>%

--- a/R/zchunk_L141.hfc_R_S_T_Y.R
+++ b/R/zchunk_L141.hfc_R_S_T_Y.R
@@ -188,6 +188,7 @@ module_emissions_L141.hfc_R_S_T_Y <- function(command, ...) {
       mutate(adj_emissions = emissions * scaler) %>%
       group_by(GCAM_region_ID, supplysector, subsector, stub.technology, Non.CO2, year) %>%
       summarise(adj_emissions = sum(adj_emissions, na.rm = TRUE)) %>%
+      ungroup() %>%
       replace_na(list(adj_emissions = 0)) %>%  #replace NAs with zero. Some sectors have zero emissions.
       rename(value = adj_emissions)
 

--- a/R/zchunk_LA143.HDDCDD.R
+++ b/R/zchunk_LA143.HDDCDD.R
@@ -188,7 +188,7 @@ module_energy_LA143.HDDCDD <- function(command, ...) {
       L143.HDDCDD_scen_RG3_Y <- L143.wtHDDCDD_scen_ctry_Y %>%
         group_by(region_GCAM3, SRES, GCM, variable, year) %>%
         summarise(value = weighted.mean(value, population)) %>%
-        ungropu()
+        ungroup()
     }
 
 


### PR DESCRIPTION
since otherwise we get package check errors with dplyr 0.5 about not package rlang.  In the long term we can come up with a better solution. See #677 