### PR TITLE
Switch to using system2 instead of pipe for running the CSVToXML Java

### DIFF
--- a/R/xml.R
+++ b/R/xml.R
@@ -105,7 +105,7 @@ make_run_xml_conversion <- function() {
         dot$mi_header,
         dot$xml_file
       )
-      warning_msgs <- system2("java", args, stdout = T, stderr = T)
+      warning_msgs <- system2("java", args, stdout = TRUE, stderr = TRUE)
       unlink(tmpfn)
 
       # Note warnings and errors will have been combined together which ideally

--- a/R/xml.R
+++ b/R/xml.R
@@ -75,26 +75,44 @@ make_run_xml_conversion <- function() {
     } else if(isTRUE(use_java)) {
       java_cp <- system.file("extdata/ModelInterface", "CSVToXML.jar",
                              package = "gcamdata")
-      cmd <- c(
-        "java",
+      # Note ideally we would use the `pipe` method to run the CSVToXML conversion
+      # as this would allow us to avoid writing large CSV files to disk only to
+      # convert to XML. However it appears on Windows there is no way to "close"
+      # the pipe for STDIN without terminating the entire process.
+      # Instead we will fall back to `system2` and since (from the documentation):
+      # input    if a character vector is supplied, this is copied one string per
+      #          line to a temporary file, and the standard input of command is
+      #          redirected to the file.
+      # We will just write to a temporary file ourselves and avoid incurring _that_
+      # performance penalty as well.
+      tmpfn <- tempfile()
+      tmp_conn <- file(tmpfn, open="w")
+      for(i in seq_along(dot$data_tables)) {
+        table <- dot$data_tables[[i]]
+        cat("INPUT_TABLE", file = tmp_conn, sep = "\n")
+        cat("Variable ID", file = tmp_conn, sep = "\n")
+        cat(table$header, file = tmp_conn, sep = "\n")
+        cat("", file = tmp_conn, sep = "\n")
+        utils::write.table(table$data, file = tmp_conn, sep=",", row.names = FALSE, col.names = TRUE, quote = FALSE)
+        cat("", file = tmp_conn, sep = "\n")
+      }
+      close(tmp_conn)
+      args <- c(
         "-cp", java_cp,
         "-Xmx1g", # TODO: memory limits?
         "ModelInterface.ModelGUI2.csvconv.CSVToXMLMain",
-        "-", # Read from STDIN
+        tmpfn, # Read from the temporary file
         dot$mi_header,
         dot$xml_file
       )
-      conv_pipe <- pipe(paste(cmd, collapse=" "), open = "w")
-      on.exit(close(conv_pipe))
+      warning_msgs <- system2("java", args, stdout = T, stderr = T)
+      unlink(tmpfn)
 
-      for(i in seq_along(dot$data_tables)) {
-        table <- dot$data_tables[[i]]
-        cat("INPUT_TABLE", file = conv_pipe, sep = "\n")
-        cat("Variable ID", file = conv_pipe, sep = "\n")
-        cat(table$header, file = conv_pipe, sep = "\n")
-        cat("", file = conv_pipe, sep = "\n")
-        utils::write.table(table$data, file = conv_pipe, sep=",", row.names = FALSE, col.names = TRUE, quote = FALSE)
-        cat("", file = conv_pipe, sep = "\n")
+      # Note warnings and errors will have been combined together which ideally
+      # would be separate so we can forward them to the appropriate message stream
+      # in R but for simplicity we will put them all on warning.
+      if(!is.null(warning_msgs) && length(warning_msgs) > 0) {
+        warning(warning_msgs)
       }
     }
 

--- a/tests/testthat/test_xml_conv_utils.R
+++ b/tests/testthat/test_xml_conv_utils.R
@@ -12,31 +12,27 @@ test_that("bogus MI header causes error", {
   if(!isTRUE(getOption("gcamdata.use_java"))) {
     skip("Skipping test as global option gcamdata.use_java is not TRUE")
   }
-  # TODO: need to find a way to get messages from Java (issue )
-  # conv_test <- create_xml("test.xml", "bogus.txt")
-  #
-  # expect_message(run_xml_conversion(conv_test), regex = "java.io.FileNotFoundException: bogus.txt", all = FALSE)
+  conv_test <- create_xml("test.xml", "bogus.txt")
+
+  expect_warning(run_xml_conversion(conv_test), regex = "java.io.FileNotFoundException: bogus.txt", all = FALSE)
 })
 
 test_that("converting without adding data causes error", {
   if(!isTRUE(getOption("gcamdata.use_java"))) {
     skip("Skipping test as global option gcamdata.use_java is not TRUE")
   }
-  # TODO: need to find a way to get messages from Java (See issue #102)
-  # conv_test <- create_xml("test.xml")
-  #
-  # expect_message(run_xml_conversion(conv_test), regex = "java.lang.NullPointerException", all = FALSE)
+  conv_test <- create_xml("test.xml")
+
+  expect_warning(run_xml_conversion(conv_test), regex = "java.lang.NullPointerException", all = FALSE)
 })
 
 test_that("converting bogus data causes error", {
   if(!isTRUE(getOption("gcamdata.use_java"))) {
     skip("Skipping test as global option gcamdata.use_java is not TRUE")
   }
-  # TODO: need to find a way to get messages from Java (See issue #102)
-  # create_xml("test.xml") %>%
-  #   add_xml_data("bogus", "InterestRate") -> conv_test
-  #
-  # expect_error(run_xml_conversion(conv_test))
+  expect_error(create_xml("test.xml") %>%
+    add_xml_data("bogus", "InterestRate") %>%
+    run_xml_conversion())
 })
 
 test_that("can convert single table", {
@@ -94,9 +90,7 @@ test_that("get warning for missing header", {
     # column reordering won't work with unknown headers
     add_xml_data(data2, "Will_Not_Find", column_order_lookup = NULL) ->
     conv_test
-  # TODO: need to find a way to get messages from Java (See issue #102)
-  #expect_message(run_xml_conversion(conv_test), regex = "Warning: skipping table: Will_Not_Find!", all = FALSE)
-  run_xml_conversion(conv_test)
+  expect_warning(run_xml_conversion(conv_test), regex = "Warning: skipping table: Will_Not_Find!", all = FALSE)
 
   expect_true(file.exists(test_fn))
   test_xml <- readLines(test_fn)


### PR DESCRIPTION
Switch to using system2 instead of pipe for running the CSVToXML Java process despite the performance hit since pipe wasn't behaving correctly on Windows anyhow.  As a added bonus this also closes #102.