### PR TITLE
tidyr_update

### DIFF
--- a/R/zchunk_L110.water.demand.primary.R
+++ b/R/zchunk_L110.water.demand.primary.R
@@ -103,8 +103,8 @@ module_water_L110.water.demand.primary <- function(command, ...) {
     # Reinistate old behavior for test (i.e., Middle East same as all other regions)
     # See issue #179 on gcamdata repo
      if(OLD_DATA_SYSTEM_BEHAVIOR) {
-       L110.water_demand_primary_R_S_W_m3_GJ[L110.water_demand_primary_R_S_W_m3_GJ == 21, "coefficient"] <-
-         L110.water_demand_primary_R_S_W_m3_GJ[L110.water_demand_primary_R_S_W_m3_GJ == gcam.USA_CODE, "coefficient"]
+       L110.water_demand_primary_R_S_W_m3_GJ[L110.water_demand_primary_R_S_W_m3_GJ$GCAM_region_ID == 21, "coefficient"] <-
+         L110.water_demand_primary_R_S_W_m3_GJ[L110.water_demand_primary_R_S_W_m3_GJ$GCAM_region_ID == gcam.USA_CODE, "coefficient"]
        return_data(L110.water_demand_primary_R_S_W_m3_GJ)
        } else {
        return_data(L110.water_demand_primary_R_S_W_m3_GJ)

--- a/R/zchunk_LA108.ag_Feed_R_C_Y.R
+++ b/R/zchunk_LA108.ag_Feed_R_C_Y.R
@@ -51,7 +51,8 @@ module_aglu_LA108.ag_Feed_R_C_Y <- function(command, ...) {
     L100.FAO_ag_Feed_t %>%
       select(iso, item, year, value) %>%
       left_join_error_no_match(iso_GCAM_regID, by = "iso") %>%                                     # Map in GCAM region ID
-      left_join(select(FAO_ag_items_cal_SUA, item, GCAM_commodity), by = "item") %>%               # Map in GCAM commodity
+      left_join(select(FAO_ag_items_cal_SUA, item, GCAM_commodity) %>%
+                  na.omit, by = "item") %>%                                                        # Map in GCAM commodity
       group_by(GCAM_region_ID, GCAM_commodity, year) %>%
       summarize(value = sum(value)) %>%                                                            # Aggregate by crop, region, year
       mutate(value = value * CONV_TON_MEGATON) %>%                                                 # Convert from tons to Mt

--- a/R/zchunk_LA108.ag_Feed_R_C_Y.R
+++ b/R/zchunk_LA108.ag_Feed_R_C_Y.R
@@ -48,11 +48,13 @@ module_aglu_LA108.ag_Feed_R_C_Y <- function(command, ...) {
     # Use crop-specific information from FAO, in combination with feed totals from IMAGE,
     # to calculate region/crop specific information. This ensures totals match IMAGE and shares match FAO.
     # First, calculate FAO totals by crop, region, and year. Then, use this compute % of feed from each crop in each region/year.
+
+
     L100.FAO_ag_Feed_t %>%
       select(iso, item, year, value) %>%
       left_join_error_no_match(iso_GCAM_regID, by = "iso") %>%                                     # Map in GCAM region ID
-      left_join(select(FAO_ag_items_cal_SUA, item, GCAM_commodity) %>%
-                  na.omit, by = "item") %>%                                                        # Map in GCAM commodity
+      left_join(select(FAO_ag_items_cal_SUA, item, GCAM_commodity), by = "item") %>%               # Map in GCAM commodity
+      filter(!is.na(GCAM_commodity)) %>%                                                           # Remove entries that are not GCAM comodities
       group_by(GCAM_region_ID, GCAM_commodity, year) %>%
       summarize(value = sum(value)) %>%                                                            # Aggregate by crop, region, year
       mutate(value = value * CONV_TON_MEGATON) %>%                                                 # Convert from tons to Mt


### PR DESCRIPTION
complete from tidyr 0.8.0 passes along observations that are grouped by a variable with a value of NA. This fix removes NA before complete is called so that the resulting data frames pass the old new tests. 

Addresses #858 