### PR TITLE
Modeltime_xml_check

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -63,7 +63,7 @@ modeltime.MAGICC_DEFAULT_EMISS_FILE   <- "../input/magicc/Historical Emissions/D
 modeltime.MAGICC_C_START_YEAR         <- 1705
 
 # Hector model assumptions
-modeltime.HECTOR_END_YEAR        <- 2100
+modeltime.HECTOR_END_YEAR        <- 2300
 modeltime.HECTOR_EMISSIONS_YEAR  <- 2005
 modeltime.HECTOR_INI_FILE        <- "../input/climate/hector-gcam.ini"
 

--- a/R/constants.R
+++ b/R/constants.R
@@ -63,7 +63,7 @@ modeltime.MAGICC_DEFAULT_EMISS_FILE   <- "../input/magicc/Historical Emissions/D
 modeltime.MAGICC_C_START_YEAR         <- 1705
 
 # Hector model assumptions
-modeltime.HECTOR_END_YEAR        <- 2300
+modeltime.HECTOR_END_YEAR        <- 2100
 modeltime.HECTOR_EMISSIONS_YEAR  <- 2005
 modeltime.HECTOR_INI_FILE        <- "../input/climate/hector-gcam.ini"
 

--- a/tests/testthat/compdata/modeltime/L200.hector.csv
+++ b/tests/testthat/compdata/modeltime/L200.hector.csv
@@ -3,4 +3,4 @@ Variable ID
 hector
 
 hector.end.year,emissions.switch.year,hector.ini.file,carbon.model.start.year
-2100.0,2005.0,../input/climate/hector-gcam.ini,1705.0
+2300,2005,../input/climate/hector-gcam.ini,1705


### PR DESCRIPTION
This change will allow the model time xmls to pass the xml tests.
```
 run-xml-tests.py ../old-xml/modeltime-xml ../new-xml/modeltime
3 files tested.
0 missing output files.
0 file discrepancies.
```
 See #619 for more details. 

gcamdata will still pass package checks but `L200.hector.csv` will *fail* the old new test. 