### PR TITLE
Prevent_logit.type_removal_first_half_of_897

### DIFF
--- a/R/zchunk_L202.an_input.R
+++ b/R/zchunk_L202.an_input.R
@@ -165,12 +165,12 @@ module_aglu_L202.an_input <- function(command, ...) {
 
     # L202.Supplysector_in: generic supplysector info for inputs to animal production (114-122)
     A_an_input_supplysector %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["Supplysector"]], GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), GCAM_region_names) ->
       L202.Supplysector_in
 
     # L202.SubsectorAll_in: generic subsector info for inputs to animal production technologies
     A_an_input_subsector %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["SubsectorAll"]], GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorAll"]], "logit.type"), GCAM_region_names) ->
       L202.SubsectorAll_in
 
     # L202.StubTech_in: identification of stub technologies for inputs to animal production (124-140)
@@ -223,12 +223,12 @@ module_aglu_L202.an_input <- function(command, ...) {
 
     # L202.Supplysector_an: generic animal production supplysector info (159-162)
     A_an_supplysector %>%
-      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]]), GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), GCAM_region_names) ->
       L202.Supplysector_an
 
     # L202.SubsectorAll_an: generic animal production subsector info (164-167)
     A_an_subsector %>%
-      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorAll"]]), GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorAll"]], "logit.type"), GCAM_region_names) ->
       L202.SubsectorAll_an
 
     # L202.StubTech_an: identification of stub technologies for animal production (169-171)

--- a/R/zchunk_L221.en_supply.R
+++ b/R/zchunk_L221.en_supply.R
@@ -108,7 +108,7 @@ module_energy_L221.en_supply <- function(command, ...) {
 
     # Supplysector information for upstream energy handling sectors
     A21.sector %>%
-      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]]), has_traded = TRUE,
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), has_traded = TRUE,
                            GCAM_region_names = GCAM_region_names) -> L221.Supplysector_en
 
     # Supplysector table that indicates to the model to create solved markets for them
@@ -123,7 +123,7 @@ module_energy_L221.en_supply <- function(command, ...) {
     # Subsector information
     # Subsector logit exponents of upstream energy handling sectors
     A21.subsector_logit %>%
-      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorLogit"]]), has_traded = TRUE,
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorLogit"]], "logit.type"), has_traded = TRUE,
                            GCAM_region_names = GCAM_region_names) -> L221.SubsectorLogit_en
 
     # Subsector shareweights of upstream energy handling sectors

--- a/R/zchunk_L222.en_transformation.R
+++ b/R/zchunk_L222.en_transformation.R
@@ -99,13 +99,13 @@ module_energy_L222.en_transformation <- function(command, ...) {
     # L222.Supplysector_en: Supply sector information for energy transformation sectors
 
     A22.sector %>%
-      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]]), GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), GCAM_region_names) ->
       L222.Supplysector_en
     # 2b. Subsector information
     # L222.SubsectorLogit_en: Subsector logit exponents of energy transformation sectors
 
     A22.subsector_logit %>%
-      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorLogit"]]), GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorLogit"]], "logit.type"), GCAM_region_names) ->
       L222.SubsectorLogit_en
 
     if(any(!is.na(A22.subsector_shrwt$year))) {

--- a/R/zchunk_L223.electricity.R
+++ b/R/zchunk_L223.electricity.R
@@ -175,7 +175,7 @@ module_energy_L223.electricity <- function(command, ...) {
     # ============================
 
     # Write supply sector information for electricity sector to all regions in L223.Supplysector_elec
-    L223.Supplysector_elec <- write_to_all_regions(A23.sector, LEVEL2_DATA_NAMES[["Supplysector"]], GCAM_region_names)
+    L223.Supplysector_elec <- write_to_all_regions(A23.sector, c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), GCAM_region_names)
 
     # Write electricity reserve margin and average grid capacity factor assumptions to all regions in L223.ElecReserve
     L223.ElecReserve <- write_to_all_regions(A23.sector, LEVEL2_DATA_NAMES[["ElecReserve"]], GCAM_region_names)
@@ -185,7 +185,7 @@ module_energy_L223.electricity <- function(command, ...) {
     # =========================
 
     # Write subsector logit exponents of electricity sector to all regions in L223.SubsectorLogit_elec
-    L223.SubsectorLogit_elec <- write_to_all_regions(A23.subsector_logit, LEVEL2_DATA_NAMES[["SubsectorLogit"]], GCAM_region_names)
+    L223.SubsectorLogit_elec <- write_to_all_regions(A23.subsector_logit, c(LEVEL2_DATA_NAMES[["SubsectorLogit"]], "logit.type"), GCAM_region_names)
 
     # Write subsector shareweights of electricity sector to all regions, separating those interpolating to a year in L223.SubsectorShrwt_elec:
     if(any(!is.na(A23.subsector_shrwt$year))) {

--- a/R/zchunk_L225.hydrogen.R
+++ b/R/zchunk_L225.hydrogen.R
@@ -65,14 +65,14 @@ module_energy_L225.hydrogen <- function(command, ...) {
 
     # L225.Supplysector_h2: Supply sector information for hydrogen sectors
     A25.sector %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["Supplysector"]], GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), GCAM_region_names) ->
       L225.Supplysector_h2
 
     # 1b. Subsector information
 
     # L225.SubsectorLogit_h2: Subsector logit exponents of hydrogen sectors
     A25.subsector_logit %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["SubsectorLogit"]], GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorLogit"]], "logit.type"), GCAM_region_names) ->
       L225.SubsectorLogit_h2
 
     # L225.SubsectorShrwt_h2 and L225.SubsectorShrwtFllt_h2: Subsector shareweights of hydrogen sectors

--- a/R/zchunk_L232.industry.R
+++ b/R/zchunk_L232.industry.R
@@ -144,7 +144,7 @@ module_energy_L232.industry <- function(command, ...) {
     # 1a. Supplysector information
     # L232.Supplysector_ind: Supply sector information for industry sector
     A32.sector %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["Supplysector"]], GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), GCAM_region_names) ->
       L232.Supplysector_ind
 
     # L232.FinalEnergyKeyword_ind: Supply sector keywords for industry sector
@@ -156,7 +156,7 @@ module_energy_L232.industry <- function(command, ...) {
     # 1b. Subsector information
     # L232.SubsectorLogit_ind: Subsector logit exponents of industry sector
     A32.subsector_logit %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["SubsectorLogit"]], GCAM_region_names) %>%
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorLogit"]], "logit.type"), GCAM_region_names) %>%
       anti_join(L232.rm_heat_techs_R, by = c("region", "subsector")) -> # Remove non-existent heat subsectors from each region
       L232.SubsectorLogit_ind
 

--- a/R/zchunk_L2321.cement.R
+++ b/R/zchunk_L2321.cement.R
@@ -112,7 +112,7 @@ module_energy_L2321.cement <- function(command, ...) {
     # 1a. Supplysector information
     # L2321.Supplysector_cement: Supply sector information for cement sector
     A321.sector %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["Supplysector"]], GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), GCAM_region_names) ->
       L2321.Supplysector_cement
 
     # L2321.FinalEnergyKeyword_cement: Supply sector keywords for cement sector
@@ -124,7 +124,7 @@ module_energy_L2321.cement <- function(command, ...) {
     # 1b. Subsector information
     # L2321.SubsectorLogit_cement: Subsector logit exponents of cement sector
     A321.subsector_logit %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["SubsectorLogit"]], GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorLogit"]], "logit.type"), GCAM_region_names) ->
       L2321.SubsectorLogit_cement
 
     # and L2321.SubsectorShrwtFllt_cement: Subsector shareweights of cement sector

--- a/R/zchunk_L2322.Fert.R
+++ b/R/zchunk_L2322.Fert.R
@@ -86,7 +86,7 @@ module_energy_L2322.Fert <- function(command, ...) {
     # 1a. Supplysector information
     # L2322.Supplysector_Fert: Supply sector information for fertilizer sector
     A322.sector %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["Supplysector"]], GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), GCAM_region_names) ->
       L2322.Supplysector_Fert
 
     # L2322.FinalEnergyKeyword_Fert: Supply sector keywords for fertilizer sector
@@ -98,7 +98,7 @@ module_energy_L2322.Fert <- function(command, ...) {
     # 2b. Subsector information
     # L2322.SubsectorLogit_Fert: Subsector logit exponents of fertilizer sector
     A322.subsector_logit %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["SubsectorLogit"]], GCAM_region_names) ->
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorLogit"]], "logit.type"), GCAM_region_names) ->
       L2322.SubsectorLogit_Fert
 
     # L2322.SubsectorShrwtFllt_Fert: Subsector shareweights of fertilizer sector

--- a/R/zchunk_L252.transportation.R
+++ b/R/zchunk_L252.transportation.R
@@ -74,7 +74,7 @@ module_energy_L252.transportation <- function(command, ...) {
     # PART A: SUPPLYSECTOR INFORMATION
     # Write supply sector information for transportation sector for all regions
     A52.sector %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["Supplysector"]],
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"),
                            GCAM_region_names = GCAM_region_names) ->
       L252.Supplysector_trn # OUTPUT
 
@@ -88,7 +88,7 @@ module_energy_L252.transportation <- function(command, ...) {
     # PART B: SUBSECTOR INFORMATION
     # Write subsector logit exponents of transportation sector for all regions
     A52.subsector_logit %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["SubsectorLogit"]],
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["SubsectorLogit"]], "logit.type"),
                            GCAM_region_names = GCAM_region_names) ->
       L252.SubsectorLogit_trn # OUTPUT
 

--- a/R/zchunk_L254.transportation_UCD.R
+++ b/R/zchunk_L254.transportation_UCD.R
@@ -171,10 +171,10 @@ module_energy_L254.transportation_UCD <- function(command, ...) {
     r_ss_all <- bind_rows(L254.StubTranTech, L254.StubTech_passthru, L254.StubTech_nonmotor)
 
     A54.sector %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["Supplysector"]], GCAM_region_names = GCAM_region_names) %>%
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type"), GCAM_region_names = GCAM_region_names) %>%
       # Subset only the combinations of region and supplysector that are available in the stub technology table
       semi_join(r_ss_all, by = c("region", "supplysector")) %>%
-      select(LEVEL2_DATA_NAMES[["Supplysector"]]) ->
+      select(c(LEVEL2_DATA_NAMES[["Supplysector"]], "logit.type")) ->
       L254.Supplysector_trn # OUTPUT
 
     # L254.FinalEnergyKeyword_trn: Supply sector keywords for transportation sector
@@ -193,10 +193,10 @@ module_energy_L254.transportation_UCD <- function(command, ...) {
 
     # A54.tranSubsector_logit reports transportation default subsector logit exponents
     A54.tranSubsector_logit %>%
-      write_to_all_regions(LEVEL2_DATA_NAMES[["tranSubsectorLogit"]], GCAM_region_names = GCAM_region_names) %>%
+      write_to_all_regions(c(LEVEL2_DATA_NAMES[["tranSubsectorLogit"]], "logit.type"), GCAM_region_names = GCAM_region_names) %>%
       # Subset only the combinations of region, supplysector, and tranSubsector that are available
       semi_join(r_ss_ts_all, by = c("region", "supplysector", "tranSubsector")) %>%
-      select(LEVEL2_DATA_NAMES[["tranSubsectorLogit"]]) ->
+      select(c(LEVEL2_DATA_NAMES[["tranSubsectorLogit"]], "logit.type")) ->
       L254.tranSubsectorLogit # OUTPUT
 
     # L254.tranSubsectorShrwt and L254.tranSubsectorShrwtFllt: Subsector shareweights of transportation sector

--- a/R/zchunk_batch_ssp15_emissions_factors_xml.R
+++ b/R/zchunk_batch_ssp15_emissions_factors_xml.R
@@ -22,6 +22,9 @@ module_emissions_batch_ssp15_emissions_factors_xml <- function(command, ...) {
     L251.ssp15_ef <- get_data(all_data, "L251.ssp15_ef")
     L251.ssp15_ef_vin <- get_data(all_data, "L251.ssp15_ef_vin")
 
+    # Silence pacakge checks
+    emiss.coeff <- NULL
+
     # ===================================================
 
     # Rename L251.ssp15_ef column to match the L2 data names

--- a/R/zchunk_batch_ssp2_emissions_factors_xml.R
+++ b/R/zchunk_batch_ssp2_emissions_factors_xml.R
@@ -22,6 +22,9 @@ module_emissions_batch_ssp2_emissions_factors_xml <- function(command, ...) {
     L251.ssp2_ef <- get_data(all_data, "L251.ssp2_ef")
     L251.ssp2_ef_vin <- get_data(all_data, "L251.ssp2_ef_vin")
 
+    # Silence package checks
+    emiss.coeff <- NULL
+
     # ===================================================
 
     # Rename L251.ssp2_ef column to match the expected column

--- a/R/zchunk_batch_ssp34_emissions_factors_xml.R
+++ b/R/zchunk_batch_ssp34_emissions_factors_xml.R
@@ -22,6 +22,9 @@ module_emissions_batch_ssp34_emissions_factors_xml <- function(command, ...) {
     L251.ssp34_ef <- get_data(all_data, "L251.ssp34_ef")
     L251.ssp34_ef_vin <- get_data(all_data, "L251.ssp34_ef_vin")
 
+    # Silence package checks
+    emiss.coeff <- NULL
+
     # ===================================================
 
     # Rename L251.ssp34_ef column to match the header names


### PR DESCRIPTION
This PR will fix the first half of the problem files listed in #897 by preserving the `logit.type` column loigit tables. 