### PR TITLE
Bugfix in get_data to allow passing data with zero rows of data.

### DIFF
--- a/R/utils-data.R
+++ b/R/utils-data.R
@@ -208,7 +208,7 @@ get_data <- function(all_data, name) {
   # If a chunk's output is missing, it returns a tibble with all NA values
   # In this case we don't want to copy it to main data list, so that subsequent
   # chunks an easily check for its status via is.null()
-  if(all(is.na(all_data[[name]]))) {
+  if(nrow(all_data[[name]]) > 0 && all(is.na(all_data[[name]]))) {
     return(NULL)
   }
   all_data[[name]]

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,7 +31,7 @@ load_csv_files <- function(filenames, optionals, quiet = FALSE, ...) {
 
     if(is.null(fqfn)) {
       assert_that(optionals[fnum]) # if we get back a NULL, file has to be optional
-      filedata[[f]] <- NA
+      filedata[[f]] <- missing_data()
       if(!quiet) message("Note: optional input ", f, "not found")
       next
     }

--- a/tests/testthat/test_datautil.R
+++ b/tests/testthat/test_datautil.R
@@ -40,7 +40,7 @@ test_that("add/get/remove data work", {
   expect_equal(length(all_data), 0)
 
   d1 <- tibble(x = 1:3)
-  d2 <- NA   # optional input, not found
+  d2 <- missing_data()   # optional input, not found
 
   expect_error(add_data(list(d1, cars, iris))) # no names
   all_data <- add_data(return_data(d1, cars, iris, d2), all_data)

--- a/tests/testthat/test_fileutil.R
+++ b/tests/testthat/test_fileutil.R
@@ -28,7 +28,7 @@ test_that("handle empty input", {
 test_that("nonexistent file", {
   expect_error(load_csv_files("SDFKJFDJKSHGF", optionals = FALSE, quiet = TRUE))
   expect_silent(x <- load_csv_files("SDFKJFDJKSHGF", optionals = TRUE, quiet = TRUE))
-  expect_true(is.na(x))
+  expect_equal(x[[1]], missing_data())
   expect_error(find_csv_file("SDFKJFDJKSHGF", optional = FALSE, quiet = TRUE))
   expect_silent(x <- find_csv_file("SDFKJFDJKSHGF", optional = TRUE, quiet = TRUE))
   expect_null(x)
@@ -60,10 +60,12 @@ test_that("save_chunkdata saves", {
   df2 <- readr::read_csv(out)
   expect_equal(df, df2)
 
-  # Handles NAs in data list?
-  NAdf <- NA
+  # Handles missing_data in data list
+  NAdf <- missing_data()
   all_data <- add_data(return_data(NAdf), all_data)
   expect_silent(save_chunkdata(all_data, outputs_dir = td))
+  out <- file.path(td, "NAdf.csv")
+  expect_false(file.exists(out))
 })
 
 test_that("save_chunkdata does comments and flags", {


### PR DESCRIPTION
Note the fix wouldn't properly handle passing NA data which was
currently being used for OPTIONAL_FILE.  I switched it so we use
missing_data() for this purpose instead which is more consistent
anyways.

This clsoes #905.