### PR TITLE
Fix gcam usa dummy logit tags

### DIFF
--- a/R/zchunk_batch_Cstorage_USA_xml.R
+++ b/R/zchunk_batch_Cstorage_USA_xml.R
@@ -44,8 +44,8 @@ module_gcamusa_batch_Cstorage_USA_xml <- function(command, ...) {
       add_xml_data(L261.DeleteSubsector_USAC,"DeleteSubsector") %>%
       add_xml_data(L261.DepRsrc_FERC,"DepRsrc") %>%
       add_xml_data(L261.DepRsrcCurves_FERC,"DepRsrcCurves") %>%
-      add_xml_data(L261.Supplysector_C_USA,"Supplysector") %>%
-      add_xml_data(L261.SubsectorLogit_C_USA,"SubsectorLogit") %>%
+      add_logit_tables_xml(L261.Supplysector_C_USA,"Supplysector") %>%
+      add_logit_tables_xml(L261.SubsectorLogit_C_USA,"SubsectorLogit") %>%
       add_xml_data(L261.SubsectorShrwtFllt_C_USA,"SubsectorShrwtFllt") %>%
       add_xml_data(L261.StubTech_C_USA,"StubTech") %>%
       add_xml_data(L261.StubTechMarket_C_USA,"StubTechMarket") %>%

--- a/R/zchunk_batch_Fert_USA_xml.R
+++ b/R/zchunk_batch_Fert_USA_xml.R
@@ -46,7 +46,7 @@ module_gcamusa_batch_Fert_USA_xml <- function(command, ...) {
     create_xml("Fert_USA.xml") %>%
       add_xml_data(L2322.DeleteSubsector_USAFert,"DeleteSubsector") %>%
       add_xml_data(L2322.FinalEnergyKeyword_USAFert,"FinalEnergyKeyword") %>%
-      add_xml_data(L2322.SubsectorLogit_USAFert,"SubsectorLogit") %>%
+      add_logit_tables_xml(L2322.SubsectorLogit_USAFert,"SubsectorLogit") %>%
       add_xml_data(L2322.SubsectorShrwtFllt_USAFert,"SubsectorShrwtFllt") %>%
       add_xml_data(L2322.SubsectorInterp_USAFert,"SubsectorInterp") %>%
       add_xml_data(L2322.TechShrwt_USAFert,"TechShrwt") %>%


### PR DESCRIPTION
This PR removes the `dummy-logit-tags` from the gcam usa module xmls.