### PR TITLE
Change XML options

### DIFF
--- a/R/onload.R
+++ b/R/onload.R
@@ -3,8 +3,11 @@
 .onLoad <- function(libname, pkgname) {
   op <- options()
   op.gcamdata <- list(
-    gcamdata.use_java = isTRUE(as.logical(Sys.getenv("GCAMDATA_USE_JAVA")))
+    gcamdata.use_java = TRUE
   )
+  if(Sys.getenv("GCAMDATA_USE_JAVA") != "") {
+    op.gcamdata[["gcamdata.use_java"]] <- isTRUE(as.logical(Sys.getenv("GCAMDATA_USE_JAVA")))
+  }
   toset <- !(names(op.gcamdata) %in% names(op))
   if(any(toset)) {
     options(op.gcamdata[toset])

--- a/R/utils.R
+++ b/R/utils.R
@@ -214,10 +214,13 @@ find_csv_file <- function(filename, optional, quiet = FALSE) {
 #' @param chunkdata Named list of tibbles (data frames) to write
 #' @param write_inputs Write data that were read as inputs, not computed? Logical
 #' @param create_dirs Create directory if necessary, and delete contents? Logical
+#' @param write_outputs Write all chunk outputs to disk?
+#' @param write_xml Write XML Batch chunk outputs to disk?
 #' @param outputs_dir Directory to save data into
 #' @param xml_dir Directory to save XML results into
 #' @importFrom assertthat assert_that
 save_chunkdata <- function(chunkdata, write_inputs = FALSE, create_dirs = FALSE,
+                           write_outputs = TRUE, write_xml = write_outputs,
                            outputs_dir = OUTPUTS_DIR, xml_dir = XML_DIR) {
   assert_that(is_data_list(chunkdata))
   assert_that(is.logical(write_inputs))
@@ -237,10 +240,12 @@ save_chunkdata <- function(chunkdata, write_inputs = FALSE, create_dirs = FALSE,
     if(is.null(cd)) next   # optional file that wasn't found
 
     if(FLAG_XML %in% get_flags(cd)) {
-      # TODO: worry about absolute paths?
-      cd$xml_file <- file.path(xml_dir, cd$xml_file)
-      run_xml_conversion(cd)
-    } else {
+      if(write_xml) {
+        # TODO: worry about absolute paths?
+        cd$xml_file <- file.path(xml_dir, cd$xml_file)
+        run_xml_conversion(cd)
+      }
+    } else if(write_outputs) {
       fqfn <- file.path(outputs_dir, paste0(cn, ".csv"))
       suppressWarnings(file.remove(fqfn))
 

--- a/man/driver.Rd
+++ b/man/driver.Rd
@@ -8,8 +8,8 @@ driver(all_data = empty_data(), stop_before = NULL, stop_after = NULL,
   return_inputs_of = stop_before, return_outputs_of = stop_after,
   return_data_names = union(inputs_of(return_inputs_of),
   outputs_of(return_outputs_of)), return_data_map_only = FALSE,
-  write_outputs = !return_data_map_only, outdir = OUTPUTS_DIR,
-  xmldir = XML_DIR, quiet = FALSE)
+  write_outputs = !return_data_map_only, write_xml = write_outputs,
+  outdir = OUTPUTS_DIR, xmldir = XML_DIR, quiet = FALSE)
 }
 \arguments{
 \item{all_data}{Data to be pre-loaded into data system}
@@ -30,6 +30,8 @@ If \code{stop_after} is specified, by default that chunk's outputs are returned}
 the other \code{return_*} parameters above}
 
 \item{write_outputs}{Write all chunk outputs to disk?}
+
+\item{write_xml}{Write XML Batch chunk outputs to disk?}
 
 \item{outdir}{Location to write output data (ignored if \code{write_outputs} is \code{FALSE})}
 

--- a/man/save_chunkdata.Rd
+++ b/man/save_chunkdata.Rd
@@ -5,6 +5,7 @@
 \title{Write data produced by chunks to csv files.}
 \usage{
 save_chunkdata(chunkdata, write_inputs = FALSE, create_dirs = FALSE,
+  write_outputs = TRUE, write_xml = write_outputs,
   outputs_dir = OUTPUTS_DIR, xml_dir = XML_DIR)
 }
 \arguments{
@@ -13,6 +14,10 @@ save_chunkdata(chunkdata, write_inputs = FALSE, create_dirs = FALSE,
 \item{write_inputs}{Write data that were read as inputs, not computed? Logical}
 
 \item{create_dirs}{Create directory if necessary, and delete contents? Logical}
+
+\item{write_outputs}{Write all chunk outputs to disk?}
+
+\item{write_xml}{Write XML Batch chunk outputs to disk?}
 
 \item{outputs_dir}{Directory to save data into}
 


### PR DESCRIPTION
While incorporating gcamdata into the GCAM it became obvious we probably want to change the default behavior of the package to write the XML files as that is what we need to run GCAM.  It also occurs to me that the most common use case is to just build the XML files and skip CSVs so I thought it would be handy to be able to configure the driver to run that way (and add an `xml` target to the GCAM Makefile to call the driver that way).

Change the default for use_java to TRUE.

Split the driver option of writing outputs to be able to control if CSV is output or XML is output separately.