### PR TITLE
OLDNEW fixes for L244.building_USA

### DIFF
--- a/R/zchunk_L244.building_USA.R
+++ b/R/zchunk_L244.building_USA.R
@@ -518,20 +518,9 @@ module_gcam.usa_L244.building_USA <- function(command, ...) {
     # L244.GenericServiceSatiation_gcamusa: Satiation levels assumed for non-thermal building services
     # Just multiply the base-service by an exogenous multiplier
     L244.GenericServiceSatiation_gcamusa <- L244.GenericBaseService_gcamusa %>%
-      filter(year == max(BASE_YEARS))
-
-    # When adding floorspace, we should take floorspace from max(BASE_YEARS) as well
-    # Instead we take the first value, which ends up being floorspace from min(BASE_YEARS)
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      L244.GenericServiceSatiation_gcamusa <- L244.GenericServiceSatiation_gcamusa %>%
-        # Add floorspace
-        left_join_keep_first_only(L244.Floorspace_gcamusa, by = c(LEVEL2_DATA_NAMES[["BldNodes"]]))
-    } else {
-      L244.GenericServiceSatiation_gcamusa <- L244.GenericServiceSatiation_gcamusa %>%
-        # Add floorspace
-        left_join_error_no_match(L244.Floorspace_gcamusa, by = c(LEVEL2_DATA_NAMES[["BldNodes"]], "year"))
-    }
-    L244.GenericServiceSatiation_gcamusa <- L244.GenericServiceSatiation_gcamusa %>%
+      filter(year == max(BASE_YEARS)) %>%
+      # Add floorspace
+      left_join_error_no_match(L244.Floorspace_gcamusa, by = c(LEVEL2_DATA_NAMES[["BldNodes"]], "year")) %>%
       # Add multiplier
       left_join_error_no_match(A44.demand_satiation_mult, by = c("building.service.input" = "supplysector")) %>%
       # Satiation level = service per floorspace * multiplier
@@ -541,22 +530,9 @@ module_gcam.usa_L244.building_USA <- function(command, ...) {
 
     # L244.ThermalServiceSatiation: Satiation levels assumed for thermal building services
     L244.ThermalServiceSatiation_gcamusa <- L244.ThermalBaseService_gcamusa %>%
-      filter(year == max(BASE_YEARS))
-
-    # Since we filter L244.ThermalBaseService_gcamusa  to max(BASE_YEARS), we should take floorspace from max(BASE_YEARS) as well
-    # Instead we take the first floorspace value, which ends up being the floorspace from min(BASE_YEARS)
-    # By adding in "year" to join by, we ensure that the same year is used for floorspace and base service
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      L244.ThermalServiceSatiation_gcamusa <- L244.ThermalServiceSatiation_gcamusa %>%
-        # Add floorspace
-        left_join_keep_first_only(L244.Floorspace_gcamusa, by = c(LEVEL2_DATA_NAMES[["BldNodes"]]))
-    } else {
-      L244.ThermalServiceSatiation_gcamusa <- L244.ThermalServiceSatiation_gcamusa %>%
-        # Add floorspace
-        left_join_error_no_match(L244.Floorspace_gcamusa, by = c(LEVEL2_DATA_NAMES[["BldNodes"]], "year"))
-    }
-
-    L244.ThermalServiceSatiation_gcamusa <- L244.ThermalServiceSatiation_gcamusa %>%
+      filter(year == max(BASE_YEARS)) %>%
+      # Add floorspace
+      left_join_error_no_match(L244.Floorspace_gcamusa, by = c(LEVEL2_DATA_NAMES[["BldNodes"]], "year")) %>%
       # Add multiplier
       left_join_error_no_match(A44.demand_satiation_mult, by = c("thermal.building.service.input" = "supplysector")) %>%
       # Satiation level = service per floorspace * multiplier

--- a/inst/extdata/gcam-usa/A44.demand_satiation_mult.csv
+++ b/inst/extdata/gcam-usa/A44.demand_satiation_mult.csv
@@ -2,20 +2,20 @@
 # Title: USA Demand Satiation Multipliers
 # Units: Increase in demand per unit floorspace
 supplysector,multiplier
-resid heating,1
-resid cooling,1.1
-resid hot water,1.1
+resid heating,1.05
+resid cooling,1.15
+resid hot water,1.01
 resid lighting,1.1
 resid appliances,1.2
 resid other appliances,1.3
-resid other,1.3
-comm heating,1
+resid other,1.25
+comm heating,1.05
 comm cooling,1.1
-comm hot water,1.1
-comm ventilation,1
+comm hot water,1.05
+comm ventilation,1.01
 comm cooking,1.1
 comm lighting,1.1
-comm refrigeration,1.2
-comm office,1.3
-comm other,1.3
-comm non-building,1.3
+comm refrigeration,1.01
+comm office,1.1
+comm other,2
+comm non-building,2

--- a/inst/extdata/gcam-usa/A44.demand_satiation_mult.csv
+++ b/inst/extdata/gcam-usa/A44.demand_satiation_mult.csv
@@ -18,4 +18,4 @@ comm lighting,1.1
 comm refrigeration,1.01
 comm office,1.1
 comm other,2
-comm non-building,2
+comm non-building,1.3


### PR DESCRIPTION
Using the wrong year for floorspace(first instead of last) when calculating per floorspace building service satiation level.

Note taking care of this exposes another bug (#979) which gets fixed here too.

This effects two data products as we expect:
```
1. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 261, 353, 128, 506, 183, 616, 631, 281, 195, 419, 270[...]. Rows in y but not x: 662, 660, 659, 656, 654, 653, 651, 649, 648, 644, 643[...].
L244.GenericServiceSatiation_gcamusa.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 204, 203, 202, 200, 199, 198, 197, 196, 195, 194, 192[...]. Rows in y but not x: 204, 202, 201, 199, 198, 196, 194, 193, 192, 190, 189[...].
L244.ThermalServiceSatiation_gcamusa.csv doesn't match
```

Further statistics attached.
[diff_L244.building_USA.txt](https://github.com/JGCRI/gcamdata/files/2120664/diff_L244.building_USA.txt)

