### PR TITLE
OLDNEW aglu_batch_land_input_4_IRR_MGMT XML

### DIFF
--- a/R/zchunk_batch_land_input_4_IRR_MGMT_xml.R
+++ b/R/zchunk_batch_land_input_4_IRR_MGMT_xml.R
@@ -26,35 +26,17 @@ module_aglu_batch_land_input_4_IRR_MGMT_xml <- function(command, ...) {
 
     # ===================================================
 
-    # The old data system adds extra land nodes by mistake.
 
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      # Produce outputs
-      create_xml("land_input_4_IRR_MGMT.xml") %>%
-        add_logit_tables_xml(L2242.LN4_Logit, "LN4_Logit") %>%
-        add_rename_landnode_xml() %>%
-        add_xml_data(L2242.LN4_NodeGhostShare, "LN4_NodeGhostShare") %>%
-        add_xml_data(L2242.LN4_NodeIsGhostShareRel, "LN4_NodeIsGhostShareRel") %>%
-        add_rename_landnode_xml() %>%
-        add_precursors("L2242.LN4_Logit",
-                       "L2242.LN4_NodeGhostShare",
-                       "L2242.LN4_NodeIsGhostShareRel") ->
-        land_input_4_IRR_MGMT.xml
-
-    } else {
-
-      # Produce outputs
-      create_xml("land_input_4_IRR_MGMT.xml") %>%
-        add_logit_tables_xml(L2242.LN4_Logit, "LN4_Logit") %>%
-        add_xml_data(L2242.LN4_NodeGhostShare, "LN4_NodeGhostShare") %>%
-        add_xml_data(L2242.LN4_NodeIsGhostShareRel, "LN4_NodeIsGhostShareRel") %>%
-        add_rename_landnode_xml() %>%
-        add_precursors("L2242.LN4_Logit",
-                       "L2242.LN4_NodeGhostShare",
-                       "L2242.LN4_NodeIsGhostShareRel") ->
-        land_input_4_IRR_MGMT.xml
-    }
-
+    # Produce outputs
+    create_xml("land_input_4_IRR_MGMT.xml") %>%
+      add_logit_tables_xml(L2242.LN4_Logit, "LN4_Logit") %>%
+      add_xml_data(L2242.LN4_NodeGhostShare, "LN4_NodeGhostShare") %>%
+      add_xml_data(L2242.LN4_NodeIsGhostShareRel, "LN4_NodeIsGhostShareRel") %>%
+      add_rename_landnode_xml() %>%
+      add_precursors("L2242.LN4_Logit",
+                     "L2242.LN4_NodeGhostShare",
+                     "L2242.LN4_NodeIsGhostShareRel") ->
+      land_input_4_IRR_MGMT.xml
 
 
     return_data(land_input_4_IRR_MGMT.xml)


### PR DESCRIPTION
Remove extra land_node_rename in XML pipeline for land_input_4_IRR_MGMT which doesn't affect the substance of the XML in terms of GCAM input but just generates a lot of extra LandNode tags.

Note this won't change comparison data as it effects the XML file.  It also doesn't affect anything in terms of substance, the old version just had an extra `land_node_rename()` the end result of which call which just extra LandNode XML tags and in different order:

```
WE34383:server2 pralitp$ sort xml/land_input_4_IRR_MGMT.xml | grep -v LandNode > new.txt 
WE34383:server2 pralitp$ vi new.txt 
WE34383:server2 pralitp$ sort ~/model/gcam-core-git/input/gcamdata/xml/land_input_4_IRR_MGMT.xml | grep -v LandNode > old.txt 
WE34383:server2 pralitp$ diff -q old.txt new.txt 
WE34383:server2 pralitp$ 
```