### PR TITLE
OLDNEW for L2233.electricity_water

### DIFF
--- a/R/zchunk_L2233.electricity_water.R
+++ b/R/zchunk_L2233.electricity_water.R
@@ -418,12 +418,9 @@ module_water_L2233.electricity_water <- function(command, ...) {
       nondataCols <- names(elecTable)[defCols]
       dataCols <- names(elecTable)[!defCols]
       if(!("year" %in% nondataCols)) {
-        if(OLD_DATA_SYSTEM_BEHAVIOR) { # old data system set year to NA, which caused all rows of 1 table to be dropped
-          elecTable$year <- NA
-        } else { # setting year to any model year allows the join from L2233.TechMapYr.
-          # Note that the year column is not in the nondataCols, and as such will be dropped in select().
-          elecTable$year <- MODEL_YEARS[1]
-        }
+        # setting year to any model year allows the join from L2233.TechMapYr.
+        # Note that the year column is not in the nondataCols, and as such will be dropped in select().
+        elecTable$year <- MODEL_YEARS[1]
       }
       if(tableName == "L2233.GlobalIntTechEff_elec_cool") {
         elecTable <- filter(elecTable, minicam.energy.input != "backup_electricity")


### PR DESCRIPTION
Fix failing join due to year mismatch causing tech interpolation rules to not get copied.

This only affects one data product:
```
1. Failure: matches old data system output (@test_oldnew.R#102) ----------------
dim(olddata) not identical to dim(newdata).
1/2 mismatches
[1] 0 - 9 == -9
Dimensions are not the same for L2233.GlobalTechInterp_elec_cool.csv

2. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Incompatible type for column `from.year`: x character, y numeric
Incompatible type for column `to.year`: x character, y numeric
L2233.GlobalTechInterp_elec_cool.csv doesn't match
```

Note that in the old data system no rows were produced so a statistical comparison is not valid.  However we can see the fixed data copies through the technology interpolation rule as was the original intent:
```bash
WE34383:server2 pralitp$ cat outputs/L2233.GlobalTechInterp_elec_cool.csv 
# Auto-generated by prepGlobalTechNoCostOutputs function in L2233.electricity_water
sector.name,subsector.name,technology,apply.to,from.year,to.year,interpolation.function
elec_gas (CC),gas (CC),gas (CC) (once through),share-weight,2010,2100,s-curve
elec_gas (CC),gas (CC),gas (CC) (seawater),share-weight,2010,2100,s-curve
elec_gas (CC),gas (CC),gas (CC) (recirculating),share-weight,2010,2100,s-curve
elec_gas (CC),gas (CC),gas (CC) (cooling pond),share-weight,2010,2100,s-curve
elec_gas (CC),gas (CC),gas (CC) (dry cooling),share-weight,2010,2100,s-curve
elec_refined liquids (CC),refined liquids (CC),refined liquids (CC) (once through),share-weight,2010,2100,s-curve
elec_refined liquids (CC),refined liquids (CC),refined liquids (CC) (seawater),share-weight,2010,2100,s-curve
elec_refined liquids (CC),refined liquids (CC),refined liquids (CC) (recirculating),share-weight,2010,2100,s-curve
elec_refined liquids (CC),refined liquids (CC),refined liquids (CC) (dry cooling),share-weight,2010,2100,s-curve
WE34383:server2 pralitp$ cat ~/model/gcamdata.compdata/outputs/L2233.GlobalTechInterp_elec_cool.csv 
# Auto-generated by prepGlobalTechNoCostOutputs function in L2233.electricity_water
sector.name,subsector.name,technology,apply.to,from.year,to.year,interpolation.function
WE34383:server2 pralitp$ cat outputs/L223.GlobalTechInterp_elec.csv 
# Model years applied to assumptions in A23.globaltech_interp
sector.name,subsector.name,technology,apply.to,from.year,to.year,interpolation.function
electricity,gas,gas (CC),share-weight,2010,2100,s-curve
electricity,refined liquids,refined liquids (CC),share-weight,2010,2100,s-curve
```
