### PR TITLE
OLDNEW for L241.fgas

### DIFF
--- a/R/zchunk_L241.fgas.R
+++ b/R/zchunk_L241.fgas.R
@@ -191,27 +191,13 @@ module_emissions_L241.fgas <- function(command, ...) {
       select(region, supplysector, subsector, stub.technology, year, Non.CO2, emiss.coeff) ->
       L241.hfc_future
 
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      # Now subset only the relevant technologies and gases (i.e., drop ones whose values are zero in all years). The old data system
-      # fails to drop technologies and gases that have zero emissions in all years. I talked to Kate and she said that this
-      # this has no implications for model performance. The if(OLD_DATA_SYSTEM_BEHVAIOR) is technically unnecessary because the 0s
-      # can be left in.
-      L241.hfc_all %>%
-        mutate(year = as.numeric(year)) ->
-        L241.hfc_all
-
-    } else {
-
-      # Now subset only the relevant technologies and gases (i.e., drop ones whose values are zero in all years).
-      L241.hfc_all %>%
-        group_by(region, supplysector, subsector, stub.technology, Non.CO2) %>%
-        filter(sum(input.emissions) != 0, year %in% BASE_YEARS) %>%
-        mutate(year = as.numeric(year)) %>%
-        ungroup ->
-        L241.hfc_all
-
-    } # end of if old data system
-
+    # Now subset only the relevant technologies and gases (i.e., drop ones whose values are zero in all years).
+    L241.hfc_all %>%
+      group_by(region, supplysector, subsector, stub.technology, Non.CO2) %>%
+      filter(sum(input.emissions) != 0, year %in% BASE_YEARS) %>%
+      mutate(year = as.numeric(year)) %>%
+      ungroup ->
+      L241.hfc_all
 
     # Set the units string for the hfc and pfc gases.
     L241.pfc_all %>%


### PR DESCRIPTION
Having to do with not droping technologies for which input emissions were zero for all years.

Seems to affect a couple of other data products not directly related:
```
1. Failure: matches old data system output (@test_oldnew.R#102) ----------------
dim(olddata) not identical to dim(newdata).
1/2 mismatches
[1] 16947 - 2807 == 14140
Dimensions are not the same for L241.fgas_all_units.csv

2. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Different number of rows
L241.fgas_all_units.csv doesn't match

3. Failure: matches old data system output (@test_oldnew.R#102) ----------------
dim(olddata) not identical to dim(newdata).
1/2 mismatches
[1] 15488 - 1348 == 14140
Dimensions are not the same for L241.hfc_all.csv

4. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Different number of rows
L241.hfc_all.csv doesn't match

5. Failure: matches old data system output (@test_oldnew.R#102) ----------------
dim(olddata) not identical to dim(newdata).
1/2 mismatches
[1] 20898 - 4140 == 16758
Dimensions are not the same for L252.MAC_higwp.csv

6. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Different number of rows
L252.MAC_higwp.csv doesn't match
```

Note the statistical comparison seems to omit `L241.fgas_all_units` (due to not have any numerical values) and `L241.hfc_all` (since all differences are just dropping zero rows); `L252.MAC_higwp` differences are attached.
[diff_L241.fgas.txt](https://github.com/JGCRI/gcamdata/files/2121432/diff_L241.fgas.txt)
