### PR TITLE
OLDNEW for L243.bio_trade_input

### DIFF
--- a/R/zchunk_L243.bio_trade_input.R
+++ b/R/zchunk_L243.bio_trade_input.R
@@ -154,14 +154,6 @@ module_aglu_L243.bio_trade_input <- function(command, ...) {
       mutate(region = BIOMASS.TRADE.REGION, use.trial.market = 1) ->
       L243.SectorUseTrialMarket_Bio
 
-    if( OLD_DATA_SYSTEM_BEHAVIOR) {
-      # The old data system repeated the USA row 32 times. The xml conversion only needs the first instance.
-      L243.SectorUseTrialMarket_Bio %>%
-        repeat_add_columns(tibble(MORE = 1:32)) %>%
-        select(-MORE) ->
-        L243.SectorUseTrialMarket_Bio
-    }
-
     # Set up all of the new subsectors.
     # Copy subsector information to each region.
     # Note that "traded biomass" only goes in the BIOMASS.TRADE.REGION, but the subsector name includes the original region name


### PR DESCRIPTION
No longer repeat use.trial.market flag 32 times just to match the old data system.

This only affects one data product exactly as we expect, going from 32 rows to 1:
```
1. Failure: matches old data system output (@test_oldnew.R#102) ----------------
dim(olddata) not identical to dim(newdata).
1/2 mismatches
[1] 32 - 1 == 31
Dimensions are not the same for L243.SectorUseTrialMarket_Bio.csv

2. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Different number of rows
L243.SectorUseTrialMarket_Bio.csv doesn't match
```