### PR TITLE
OLDNEW for L210.resources

### DIFF
--- a/R/zchunk_L210.resources.R
+++ b/R/zchunk_L210.resources.R
@@ -283,20 +283,11 @@ module_energy_L210.resources <- function(command, ...) {
       select(region, renewresource = resource, sub.renewable.resource = subresource, grade, available, extractioncost)
 
     # L210.GrdRenewRsrcMax_geo: default max sub resource of geothermal (hydrothermal) resources
-    # The old code is "subset( L210.GrdRenewRsrcCurves_geo, grade = unique( grade )[1] )"
-    # It appears they meant to filter to "grade 1" only, however there is only one equals sign, so no subsetting occurs
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      L210.GrdRenewRsrcMax_geo <- L210.GrdRenewRsrcCurves_geo %>%
-        mutate(year.fillout = min(BASE_YEARS),
-               maxSubResource = 1) %>%
-        select(LEVEL2_DATA_NAMES[["maxSubResource"]])
-    } else {
-      L210.GrdRenewRsrcMax_geo <- L210.GrdRenewRsrcCurves_geo %>%
-        filter(grade == "grade 1") %>%
-        mutate(year.fillout = min(BASE_YEARS),
-               maxSubResource = 1) %>%
-        select(LEVEL2_DATA_NAMES[["maxSubResource"]])
-    }
+    L210.GrdRenewRsrcMax_geo <- L210.GrdRenewRsrcCurves_geo %>%
+      filter(grade == "grade 1") %>%
+      mutate(year.fillout = min(BASE_YEARS),
+             maxSubResource = 1) %>%
+      select(LEVEL2_DATA_NAMES[["maxSubResource"]])
 
 
     # L210.GrdRenewRsrcCurves_EGS: graded supply curves of geothermal (EGS) resources
@@ -307,20 +298,11 @@ module_energy_L210.resources <- function(command, ...) {
       select(region, renewresource = resource, sub.renewable.resource = subresource, grade, available, extractioncost)
 
     # L210.GrdRenewRsrcMax_EGS: default max sub resource of EGS resources
-    # The old code is "subset( L210.GrdRenewRsrcCurves_EGS, grade = unique( grade )[1] )"
-    # It appears they meant to filter to "grade 1" only, however there is only one equals sign, so no subsetting occurs
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      L210.GrdRenewRsrcMax_EGS <- L210.GrdRenewRsrcCurves_EGS %>%
-        mutate(year.fillout = min(BASE_YEARS),
-               maxSubResource = 1) %>%
-        select(LEVEL2_DATA_NAMES[["maxSubResource"]])
-    } else {
-      L210.GrdRenewRsrcMax_EGS <- L210.GrdRenewRsrcCurves_EGS %>%
-        filter(grade == "grade 1") %>%
-        mutate(year.fillout = min(BASE_YEARS),
-               maxSubResource = 1) %>%
-        select(LEVEL2_DATA_NAMES[["maxSubResource"]])
-    }
+    L210.GrdRenewRsrcMax_EGS <- L210.GrdRenewRsrcCurves_EGS %>%
+      filter(grade == "grade 1") %>%
+      mutate(year.fillout = min(BASE_YEARS),
+             maxSubResource = 1) %>%
+      select(LEVEL2_DATA_NAMES[["maxSubResource"]])
 
     # L210.GrdRenewRsrcCurves_tradbio: graded supply curves of traditional biomass resources
     L210.GrdRenewRsrcCurves_tradbio <- L117.RsrcCurves_EJ_R_tradbio %>%


### PR DESCRIPTION
Fix subset which was meant to select only one grade by region.  The numbers do not change, just the values get repeated more than they need to be.

This directly affects the geothermal maxSubResource for regular and EGS sub resources and also affects the GCAM-USA geothermal resource:
```
1. Failure: matches old data system output (@test_oldnew.R#102) ----------------
dim(olddata) not identical to dim(newdata).
1/2 mismatches
[1] 64 - 32 == 32
Dimensions are not the same for L210.GrdRenewRsrcMax_EGS.csv

2. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Different number of rows
L210.GrdRenewRsrcMax_EGS.csv doesn't match

3. Failure: matches old data system output (@test_oldnew.R#102) ----------------
dim(olddata) not identical to dim(newdata).
1/2 mismatches
[1] 26 - 13 == 13
Dimensions are not the same for L210.GrdRenewRsrcMax_geo_USA.csv

4. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Different number of rows
L210.GrdRenewRsrcMax_geo_USA.csv doesn't match

5. Failure: matches old data system output (@test_oldnew.R#102) ----------------
dim(olddata) not identical to dim(newdata).
1/2 mismatches
[1] 64 - 32 == 32
Dimensions are not the same for L210.GrdRenewRsrcMax_geo.csv

6. Failure: matches old data system output (@test_oldnew.R#115) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Different number of rows
L210.GrdRenewRsrcMax_geo.csv doesn't match
```

Again there is no statistical comparison because the actual data does not change, just repeated more than it needed to be.