### PR TITLE
OLDNEW - L110.water.demand.primary

### DIFF
--- a/R/zchunk_L110.water.demand.primary.R
+++ b/R/zchunk_L110.water.demand.primary.R
@@ -100,15 +100,7 @@ module_water_L110.water.demand.primary <- function(command, ...) {
                      "water/resource_water_share") ->
       L110.water_demand_primary_R_S_W_m3_GJ
 
-    # Reinistate old behavior for test (i.e., Middle East same as all other regions)
-    # See issue #179 on gcamdata repo
-     if(OLD_DATA_SYSTEM_BEHAVIOR) {
-       L110.water_demand_primary_R_S_W_m3_GJ[L110.water_demand_primary_R_S_W_m3_GJ$GCAM_region_ID == 21, "coefficient"] <-
-         L110.water_demand_primary_R_S_W_m3_GJ[L110.water_demand_primary_R_S_W_m3_GJ$GCAM_region_ID == gcam.USA_CODE, "coefficient"]
-       return_data(L110.water_demand_primary_R_S_W_m3_GJ)
-       } else {
-       return_data(L110.water_demand_primary_R_S_W_m3_GJ)
-       }
+      return_data(L110.water_demand_primary_R_S_W_m3_GJ)
 
   } else {
     stop("Unknown command")


### PR DESCRIPTION
This code changes two files: `L110.water_demand_primary_R_S_W_m3_GJ` and `L210.TechCoef`. The changes are small in absolute value but large in percentage change. They are all changes to the Middle East, which used to be given the coefficients for USA, but now use their own calculated values.

![diff_l110](https://user-images.githubusercontent.com/25437326/41712668-15e497a0-7519-11e8-9392-b13ad2cb6896.png)