### PR TITLE
OLDNEW for LB134.Diet_Rfao

### DIFF
--- a/R/zchunk_LB134.Diet_Rfao.R
+++ b/R/zchunk_LB134.Diet_Rfao.R
@@ -267,15 +267,7 @@ module_aglu_LB134.Diet_Rfao <- function(command, ...) {
       # Cap future values, both maximum annual change (ratio)
       # and absolute value, based on values in A_FoodDemand_SSPs
 
-      # Note that the old code has a bug: in line 168 (old file) a loop starts without
-      # correctly resetting the `prev_i` variable; as a result, if the value in
-      # the final historical year is 0, incorrect values get written to all future
-      # years -- but only for meat. We replicate this faulty behavior below.
-      if(OLD_DATA_SYSTEM_BEHAVIOR) {
-        prev_yr <- max(FUTURE_YEARS)  # bug
-      } else {
-        prev_yr <- max(HISTORICAL_YEARS)
-      }
+      prev_yr <- max(HISTORICAL_YEARS)
       # Because of the dependencies involved, I couldn't figure out a way
       # not to use a loop here.  :(
       for(yr in sort(FUTURE_YEARS)) {


### PR DESCRIPTION
Having to do with starting a loop with the wrong "prev_year" (last model year instead of last historical year).

The upshot is we get the "wrong' income elasticities in the first future year in the SSPs.  From the statistical comparison it seems some of these can be significant.

```
1. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 3420, 3419, 3418, 3413, 3412, 3411, 3410, 3409, 3407, 3406, 3124[...]. Rows in y but not x: 3418, 3416, 3415, 3410, 3409, 3407, 3406, 3405, 3125, 3123, 3121[...]. 
L134.pcFood_kcald_R_Dmnd_Y_ssp1.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 3420, 3418, 3415, 3410, 3409, 3408, 3405, 3126, 3125, 3124, 3121[...]. Rows in y but not x: 3418, 3416, 3415, 3414, 3410, 3407, 3126, 3125, 3123, 3120, 3119[...]. 
L134.pcFood_kcald_R_Dmnd_Y_ssp2.csv doesn't match

3. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 3418, 3416, 3413, 3411, 3409, 3408, 3406, 3123, 3122, 3121, 3119[...]. Rows in y but not x: 3418, 3416, 3415, 3410, 3409, 3407, 3406, 3405, 3123, 3122, 3121[...]. 
L134.pcFood_kcald_R_Dmnd_Y_ssp3.csv doesn't match

4. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 3418, 3414, 3413, 3410, 3409, 3408, 3406, 3405, 3416, 3121, 3120[...]. Rows in y but not x: 3416, 3415, 3414, 3410, 3407, 3406, 3405, 3122, 3121, 3120, 3119[...]. 
L134.pcFood_kcald_R_Dmnd_Y_ssp4.csv doesn't match

5. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 3420, 3414, 3413, 3412, 3411, 3409, 3407, 3405, 3126, 3125, 3124[...]. Rows in y but not x: 3418, 3416, 3415, 3414, 3410, 3409, 3407, 3406, 3405, 3126, 3125[...]. 
L134.pcFood_kcald_R_Dmnd_Y_ssp5.csv doesn't match

6. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 1043, 1042, 1041, 1040, 947, 948, 853, 620, 631, 613, 594[...]. Rows in y but not x: 1043, 1042, 1040, 1027, 948, 638, 637, 631, 621, 613, 594[...]. 
L203.IncomeElasticity_SSP1.csv doesn't match

7. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 1040, 949, 1043, 853, 854, 637, 619, 577, 613, 621, 1027[...]. Rows in y but not x: 1043, 1042, 1040, 1027, 949, 948, 853, 620, 619, 577, 613[...]. 
L203.IncomeElasticity_SSP2.csv doesn't match

8. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 1042, 1040, 1043, 847, 613, 852, 577, 854, 618, 1027, 946[...]. Rows in y but not x: 1043, 1041, 1040, 1039, 1027, 946, 853, 852, 636, 613, 577[...]. 
L203.IncomeElasticity_SSP3.csv doesn't match

9. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 1041, 1040, 852, 853, 637, 631, 1042, 618, 594, 577, 635[...]. Rows in y but not x: 1041, 1040, 1039, 1027, 945, 854, 853, 637, 636, 635, 577[...]. 
L203.IncomeElasticity_SSP4.csv doesn't match

10. Failure: matches old data system output (@test_oldnew.R#112) ---------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 1043, 1042, 1041, 637, 854, 853, 855, 631, 620, 577, 949[...]. Rows in y but not x: 1043, 1042, 1027, 855, 854, 621, 620, 638, 1041, 631, 847[...]. 
L203.IncomeElasticity_SSP5.csv doesn't match
```

[diff_LB134.Diet_Rfao.txt](https://github.com/JGCRI/gcamdata/files/2134208/diff_LB134.Diet_Rfao.txt)
