### PR TITLE
OLDNEW for L123.bcoc_awb_R_S_T_Y

### DIFF
--- a/R/zchunk_L123.bcoc_awb_R_S_T_Y.R
+++ b/R/zchunk_L123.bcoc_awb_R_S_T_Y.R
@@ -46,28 +46,15 @@ module_emissions_L123.bcoc_awb_R_S_T_Y <- function(command, ...) {
       mutate(Non.CO2 = "OC_AWB") -> OC_AWB_2000
 
     # Aggregate BC and OC emissions to GCAM regions and convert to Tg
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      # Old system used match and ended up with just the first value instead of summing all values
-      bind_rows(OC_AWB_2000, BC_AWB_2000) %>%
+    bind_rows(OC_AWB_2000, BC_AWB_2000) %>%
       # Not all iso's will necesarilly have an input value. This is ok, but use left_join becuase of this.
       left_join(iso_GCAM_regID, by = "iso") %>%
       group_by(Non.CO2, GCAM_region_ID) %>%
-      summarise(awb = first(awb)) %>%
+      summarize_if(is.numeric , sum) %>%
       filter(!is.na(awb)) %>%
       mutate(awb = awb * CONV_KG_TO_TG) %>%
       ungroup() ->
       BCOC_AWB_2000
-    } else {
-        bind_rows(OC_AWB_2000, BC_AWB_2000) %>%
-        # Not all iso's will necesarilly have an input value. This is ok, but use left_join becuase of this.
-        left_join(iso_GCAM_regID, by = "iso") %>%
-        group_by(Non.CO2, GCAM_region_ID) %>%
-        summarize_if(is.numeric , sum) %>%
-        filter(!is.na(awb)) %>%
-        mutate(awb = awb * CONV_KG_TO_TG) %>%
-        ungroup() ->
-        BCOC_AWB_2000
-   }
 
     # Extract only 2000 data from ag production data
     filter(L103.ag_Prod_Mt_R_C_Y_GLU, year == 2000) %>%


### PR DESCRIPTION
Having to do with matching first the first value instead of aggregating all.

It affects the following data outputs:
```
1. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 6252, 6236, 6232, 6226, 6222, 6192, 6188, 6178, 6170, 6166, 6160[...]. Rows in y but not x: 6236, 6232, 6222, 6214, 6210, 6204, 6200, 6192, 6178, 6170, 6166[...]. 
L123.bcoc_tgmt_R_awb_2000.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 25008, 25007, 25005, 24976, 24975, 24974, 24973, 24928, 24927, 24925, 24904[...]. Rows in y but not x: 25008, 25006, 25005, 24976, 24944, 24942, 24927, 24926, 24903, 24888, 24887[...]. 
L211.AWB_BCOC_EmissCoeff.csv doesn't match

3. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 50016, 50015, 50013, 50012, 50011, 50010, 50009, 49952, 49951, 49949, 49945[...]. Rows in y but not x: 50016, 50013, 50010, 50009, 49952, 49950, 49948, 49947, 49945, 49888, 49886[...]. 
L2111.AWB_BCOC_EmissCoeff.csv doesn't match

4. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 100031, 100026, 100025, 100024, 100023, 100021, 100020, 100017, 99904, 99903, 99902[...]. Rows in y but not x: 100032, 100029, 100028, 100023, 100022, 100017, 99904, 99902, 99900, 99896, 99895[...]. 
L2112.AWB_BCOC_EmissCoeff.csv doesn't match
```

Statistical differences seem small although I am not sure of the units.
[diff_L123.bcoc_awb_R_S_T_Y.txt](https://github.com/JGCRI/gcamdata/files/2138154/diff_L123.bcoc_awb_R_S_T_Y.txt)
