### PR TITLE
OLDNEW-L124.nonco2_unmgd_R_S_T_Y

### DIFF
--- a/R/zchunk_L124.nonco2_unmgd_R_S_T_Y.R
+++ b/R/zchunk_L124.nonco2_unmgd_R_S_T_Y.R
@@ -66,27 +66,9 @@ module_emissions_L124.nonco2_unmgd_R_S_T_Y <- function(command, ...) {
       standardize_iso(col = "ISO_A3") %>%
       change_iso_code('rou', 'rom') %>%                                                 # Switch Romania iso code to its pre-2002 value
       left_join(iso_GCAM_regID, by = "iso") %>%                                         # Map in GCAM regions
-      select(IPCC, Non.CO2, sector, iso, GCAM_region_ID, year, value) ->
+      select(IPCC, Non.CO2, sector, iso, GCAM_region_ID, year, value) %>%
+      na.omit() ->
       EDGAR_history
-
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      # The old data system processed data in wide format. There was a na.omit() in the code that effectively removed
-      # any region/sector combination where the time series was incomplete. We'd like to keep this information.
-      # Additionally, the old data system never included NH3 in the processing. The emissions are small
-      # but we should keep them.
-      EDGAR_history %>%
-        filter(Non.CO2 != "NH3") %>%                                                    # Remove NH3 for consistency with old data
-        filter(year <= 2008) %>%                                                         # Old data didn't care if post-2008 data was missing so remove it here
-        spread(year, value) %>%                                                          # Convert to wide format
-        na.omit() %>%                                                                    # Remove any row with an NA (i.e., incomplete time series)
-        gather_years ->                                             # Convert year back to integer form (not sure why this changes type)
-        EDGAR_history
-
-    } else {
-      EDGAR_history %>%
-        na.omit() ->
-        EDGAR_history
-    }
 
     # Prepare EDGAR emissions for use (continued)
     EDGAR_history %>%


### PR DESCRIPTION
This one is pretty ugly. The changes in the code keep EDGAR emissions that shouldn't have been deleted. This includes various gases from some regions and NH3 for all regions.

26 files are changes. All of them have new rows. Some have changed values as well. The value changes are sometimes fairly large in terms of percentages. Most of the extremely large changes are dealing with very small absolute changes.

Files changed:
L124.deforest_coefs,
L124.nonco2_tg_R_forest_Y_GLU,
L124.nonco2_tg_R_grass_Y_GLU,
L212.AgSupplySector,
L212.AgSupplySubsector,
L212.FORESTEmissions_D_noprot,
L212.FORESTEmissions_D_prot,
L212.FORESTEmissions_D,
L212.FORESTEmissions_FF_noprot,
L212.FORESTEmissions_FF_prot,
L212.FORESTEmissions_FF,
L212.FORESTEmissionsFactors_BCOC_D_noprot,
L212.FORESTEmissionsFactors_BCOC_D_prot,
L212.FORESTEmissionsFactors_BCOC_D,
L212.FORESTEmissionsFactors_BCOC_FF_noprot,
L212.FORESTEmissionsFactors_BCOC_FF_prot,
L212.FORESTEmissionsFactors_BCOC_FF,
L212.FORESTEmissionsFactors_future,
L212.GRASSEmissions_noprot,
L212.GRASSEmissions_prot,
L212.GRASSEmissions,
L212.GRASSEmissionsFactors_BCOC_noprot,
L212.GRASSEmissionsFactors_BCOC_prot,
L212.GRASSEmissionsFactors_BCOC,
L212.ItemName_prot,
L212.ItemName

![diff_l124](https://user-images.githubusercontent.com/25437326/41931475-355ed05a-794c-11e8-859d-90c5ac06e613.png)

