### PR TITLE
OLDNEW for L112.ghg_en_R_S_T_Y

### DIFF
--- a/R/zchunk_L112.ghg_en_R_S_T_Y.R
+++ b/R/zchunk_L112.ghg_en_R_S_T_Y.R
@@ -51,39 +51,20 @@ module_emissions_L112.ghg_en_R_S_T_Y <- function(command, ...) {
       mutate(Non.CO2 = "N2O")
 
     # Computing unscaled EPA emissions by country and technology
-    # This is wrong because by joining only on fuel and sector, not technology, we incorrectly assign
-    # natural gas emissions factors to all passenger transport, even refined liquid passenger transport
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      L112.ghg_tg_R_en_Si_F_Yh <- L101.in_EJ_R_en_Si_F_Yh %>%
-        left_join_keep_first_only(GCAM_sector_tech %>%
-                                    select(EPA_agg_sector, EPA_agg_fuel, EDGAR_agg_sector, fuel, sector),
-                                  by = c("fuel", "sector")) %>%
-        # Remove years where we don't have emissions data and add Non.CO2 column
-        filter(year %in% emissions.EDGAR_YEARS) %>%
-        repeat_add_columns(tibble(Non.CO2 = c("CH4", "N2O"))) %>%
-        # Match in emissions factors
-        # Use left_join because some "cement" only in EPA sector
-        left_join(L102.ghg_tgej_USA_en_Sepa_F_2005,
-                  by = c("Non.CO2" = "variable", "EPA_agg_sector" = "sector", "EPA_agg_fuel" = "fuel")) %>%
-        # Compute unscaled emissions
-        mutate(epa_emissions = energy * emiss_factor) %>%
-        na.omit()
-    } else {
-      L112.ghg_tg_R_en_Si_F_Yh <- L101.in_EJ_R_en_Si_F_Yh %>%
-        left_join_keep_first_only(GCAM_sector_tech %>%
-                                    select(EPA_agg_sector, EPA_agg_fuel, EDGAR_agg_sector, fuel, sector, technology),
-                                  by = c("fuel", "sector", "technology")) %>%
-        # Remove years where we don't have emissions data and add Non.CO2 column
-        filter(year %in% emissions.EDGAR_YEARS) %>%
-        repeat_add_columns(tibble(Non.CO2 = c("CH4", "N2O"))) %>%
-        # Match in emissions factors
-        # Use left_join because some "cement" only in EPA sector
-        left_join(L102.ghg_tgej_USA_en_Sepa_F_2005,
-                  by = c("Non.CO2" = "variable", "EPA_agg_sector" = "sector", "EPA_agg_fuel" = "fuel")) %>%
-        # Compute unscaled emissions
-        mutate(epa_emissions = energy * emiss_factor) %>%
-        na.omit()
-    }
+    L112.ghg_tg_R_en_Si_F_Yh <- L101.in_EJ_R_en_Si_F_Yh %>%
+      left_join_keep_first_only(GCAM_sector_tech %>%
+                                  select(EPA_agg_sector, EPA_agg_fuel, EDGAR_agg_sector, fuel, sector, technology),
+                                by = c("fuel", "sector", "technology")) %>%
+      # Remove years where we don't have emissions data and add Non.CO2 column
+      filter(year %in% emissions.EDGAR_YEARS) %>%
+      repeat_add_columns(tibble(Non.CO2 = c("CH4", "N2O"))) %>%
+      # Match in emissions factors
+      # Use left_join because some "cement" only in EPA sector
+      left_join(L102.ghg_tgej_USA_en_Sepa_F_2005,
+                by = c("Non.CO2" = "variable", "EPA_agg_sector" = "sector", "EPA_agg_fuel" = "fuel")) %>%
+      # Compute unscaled emissions
+      mutate(epa_emissions = energy * emiss_factor) %>%
+      na.omit()
 
     # Aggregate EPA emissions to EDGAR sector
     L112.ghg_tg_R_en_Sedgar_Yh <- L112.ghg_tg_R_en_Si_F_Yh %>%


### PR DESCRIPTION
Having to do with a join that should have included the technology.

This only affects a few data products:
```
1. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 139574, 139572, 139570, 139569, 139566, 139565, 139562, 139561, 139560, 139559, 139554[...]. Rows in y but not x: 139571, 139570, 139569, 139567, 139565, 139560, 139554, 139552, 139549, 139547, 139345[...]. 
L112.ghg_tg_R_en_S_F_Yh.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 141702, 141701, 141697, 141692, 141691, 141689, 141688, 141686, 141684, 141682, 141680[...]. Rows in y but not x: 141699, 141695, 141694, 141692, 141691, 141689, 141688, 141687, 141683, 141681, 141680[...]. 
L112.ghg_tgej_R_en_S_F_Yh.csv doesn't match

3. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 9920, 9903, 9902, 9899, 9869, 9609, 9601, 9600, 9597, 9596, 9569[...]. Rows in y but not x: 9920, 9899, 9869, 9621, 9603, 9600, 9598, 9575, 9570, 9569, 9447[...]. 
L201.en_ghg_emissions.csv doesn't match
```

But the statistical changes show they may be significant:
[diff_L112.ghg_en_R_S_T_Y.txt](https://github.com/JGCRI/gcamdata/files/2141701/diff_L112.ghg_en_R_S_T_Y.txt)
