### PR TITLE
OLDNEW for LA144.Commercial; 

### DIFF
--- a/R/zchunk_LA144.Commercial.R
+++ b/R/zchunk_LA144.Commercial.R
@@ -48,14 +48,6 @@ module_gcam.usa_LA144.Commercial <- function(command, ...) {
     states_subregions <- get_data(all_data, "gcam-usa/states_subregions") %>%
       select(subregion4, subregion9, REGION, DIVISION, state) %>%
       distinct()
-    # Because there was a mistake in previous states_subregions file, there are some values that will require
-    # a data frame identical to the mistaken one
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      states_subregions_region4calc <- states_subregions %>%
-        mutate(subregion4 = if_else(state == "WV", "Midwest", subregion4))
-    } else {
-      states_subregions_region4calc <- states_subregions_region4calc
-    }
 
     Census_pop_hist <- get_data(all_data, "gcam-usa/Census_pop_hist") %>%
       gather_years
@@ -111,7 +103,7 @@ module_gcam.usa_LA144.Commercial <- function(command, ...) {
 
     # Add subregions to census population for aggregating
     L144.Census_pop_hist <- Census_pop_hist %>%
-      left_join_error_no_match(states_subregions_region4calc, by = "state") %>%
+      left_join_error_no_match(states_subregions, by = "state") %>%
       filter(year %in% HISTORICAL_YEARS)
 
     # Aggregate population to subregion4


### PR DESCRIPTION
Having to do with a state to 4-region census division mapping that was wrong in the old data system.

This only affects a couple of data products:
```
1. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 758, 316, 70, 197, 18, 238, 367, 401, 707, 279, 14[...]. Rows in y but not x: 764, 731, 724, 707, 678, 672, 622, 595, 578, 575, 554[...]. 
L144.flsp_bm2_state_comm.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 248, 238, 229, 218, 223. Rows in y but not x: 248, 238, 223, 218, 229. 
L244.Floorspace_gcamusa.csv doesn't match
```

And the differences are small:
[diff_LA144.Commercial.txt](https://github.com/JGCRI/gcamdata/files/2141873/diff_LA144.Commercial.txt)

Which ultimately only affects 5 states:
```
WE34383:server2 pralitp$ diff ~/model/gcamdata.compdata/outputs/L244.Floorspace_gcamusa.csv compdata_updates/L244.Floorspace_gcamusa.csv 
220c220
< IL,comm,comm,comm_building,1975,0.246
---
> IL,comm,comm,comm_building,1975,0.247
225c225
< LA,comm,comm,comm_building,1975,0.063
---
> LA,comm,comm,comm_building,1975,0.062
231c231
< MS,comm,comm,comm_building,1975,0.049
---
> MS,comm,comm,comm_building,1975,0.048
240c240
< NC,comm,comm,comm_building,1975,0.093
---
> NC,comm,comm,comm_building,1975,0.092
250c250
< TX,comm,comm,comm_building,1975,0.203
---
> TX,comm,comm,comm_building,1975,0.202
```