### PR TITLE
OLDNEW for L102.ghg_en_USA_S_T_Y.R

### DIFF
--- a/R/zchunk_L102.ghg_en_USA_S_T_Y.R
+++ b/R/zchunk_L102.ghg_en_USA_S_T_Y.R
@@ -56,30 +56,15 @@ module_emissions_L102.ghg_en_USA_S_T_Y <- function(command, ...) {
       ungroup() ->
       L102.ghg_tg_USA_en_Sepa_F_2005 # GHG balance in 2005
 
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      # incorrect fuel name for transport from input mapping.
-      # organize energy balances in USA 2005
-      L101.in_EJ_R_en_Si_F_Yh %>% # start from energy balances
-        filter(GCAM_region_ID == gcam.USA_CODE, year == 2005) %>% # 2005 USA data only
-        select(-GCAM_region_ID, -year) %>%
-        left_join_keep_first_only(select(GCAM_sector_tech, sector, fuel, EPA_agg_sector, EPA_agg_fuel_ghg),
-                                  by = c("sector", "fuel")) %>% # assign aggregate sector and fuel names
-        group_by(EPA_agg_sector, EPA_agg_fuel_ghg) %>%
-        summarize_if(is.numeric, sum) -> # sum by aggregate sector and fuel
-        L102.in_EJ_USA_en_Sepa_F_2005 # energy balance in 2005
-
-    } else {
-      # foolproof solution is to use both fuel and technology for categorization.
-      # organize energy balances in USA 2005
-      L101.in_EJ_R_en_Si_F_Yh %>% # start from energy balances
-        filter(GCAM_region_ID == gcam.USA_CODE, year == 2005) %>% # 2005 USA data only
-        select(-GCAM_region_ID, -year) %>%
-        left_join(select(GCAM_sector_tech, sector, fuel, technology, EPA_agg_sector, EPA_agg_fuel_ghg),
-                  by = c("sector", "fuel", "technology")) %>% # assign aggregate sector and fuel names
-        group_by(EPA_agg_sector, EPA_agg_fuel_ghg) %>%
-        summarize_if(is.numeric, sum) -> # sum by aggregate sector and fuel
-        L102.in_EJ_USA_en_Sepa_F_2005 # energy balance in 2005
-    }
+    # organize energy balances in USA 2005
+    L101.in_EJ_R_en_Si_F_Yh %>% # start from energy balances
+      filter(GCAM_region_ID == gcam.USA_CODE, year == 2005) %>% # 2005 USA data only
+      select(-GCAM_region_ID, -year) %>%
+      left_join(select(GCAM_sector_tech, sector, fuel, technology, EPA_agg_sector, EPA_agg_fuel_ghg),
+                by = c("sector", "fuel", "technology")) %>% # assign aggregate sector and fuel names
+      group_by(EPA_agg_sector, EPA_agg_fuel_ghg) %>%
+      summarize_if(is.numeric, sum) -> # sum by aggregate sector and fuel
+      L102.in_EJ_USA_en_Sepa_F_2005 # energy balance in 2005
 
     # combine emissions and energy to get emission factors
     L102.ghg_tg_USA_en_Sepa_F_2005 %>%


### PR DESCRIPTION
Having to do with a join that should have included technology but didn't.

Closely related data products are affected:
```
1. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 26, 25, 18, 11. Rows in y but not x: 26, 25, 18, 11. 
L102.ghg_tgej_USA_en_Sepa_F_2005.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 139612, 139609, 139608, 139604, 139599, 139598, 139597, 139594, 139593, 139592, 139574[...]. Rows in y but not x: 139612, 139608, 139607, 139603, 139602, 139601, 139599, 139598, 139597, 139596, 139595[...]. 
L112.ghg_tg_R_en_S_F_Yh.csv doesn't match

3. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 141736, 141733, 141732, 141730, 141728, 141727, 141725, 141723, 141722, 141721, 141720[...]. Rows in y but not x: 141740, 141737, 141736, 141735, 141731, 141730, 141729, 141726, 141725, 141724, 141721[...]. 
L112.ghg_tgej_R_en_S_F_Yh.csv doesn't match

4. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 9923, 9921, 9920, 9906, 9903, 9870, 9869, 9624, 9617, 9612, 9611[...]. Rows in y but not x: 9923, 9912, 9911, 9906, 9903, 9902, 9890, 9875, 9870, 9869, 9621[...]. 
L201.en_ghg_emissions.csv doesn't match
```

Statistical differences:
[diff_L102.ghg_en_USA_S_T_Y.txt](https://github.com/JGCRI/gcamdata/files/2143634/diff_L102.ghg_en_USA_S_T_Y.txt)
