### PR TITLE
OLDNEW for L103.ghg_an_USA_S_T_Y

### DIFF
--- a/R/zchunk_L103.ghg_an_USA_S_T_Y.R
+++ b/R/zchunk_L103.ghg_an_USA_S_T_Y.R
@@ -44,29 +44,17 @@ module_emissions_L103.ghg_an_USA_S_T_Y <- function(command, ...) {
     # EPA data contains estimates for aggregate and disaggregate sectors. There should be NAs when
     # mapping to GCAM sector and fuel to avoid double counting those totals.
 
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-    # Old system yields an emissions estimate of 0 for poultry because it has NA values.
+    # Note summarize ignoring NA to ensure correct poltry emissions estimate,
+    # methane emissions for poultry are relatively small
+    # compared to other animals, but non-zero
     EPA_FCCC_AG_2005 %>%
       left_join(EPA_ghg_tech, by = "Source_Category") %>%
       group_by(sector, fuel) %>%
-      summarize_if(is.numeric , sum) %>%
-      filter( !is.na(sector), !is.na(fuel)) %>%
-      mutate_all(funs(replace(., is.na(.), 0))) %>%
+      summarize_if(is.numeric, sum, na.rm = TRUE) %>%
+      filter(!is.na(sector), !is.na(fuel)) %>%
+      mutate_all( funs( replace(., is.na(.), 0))) %>%
       mutate_if(is.numeric, funs(. * CONV_GG_TG)) ->
-        L103.ghg_tg_USA_an_Sepa_F_2005
-
-    } else {
-      # Corrected poltry emissions estimate, methane emissions for poultry are relatively small
-      # compared to other animals, but non-zero
-    EPA_FCCC_AG_2005 %>%
-        left_join(EPA_ghg_tech, by = "Source_Category") %>%
-        group_by(sector, fuel) %>%
-        summarize_if(is.numeric, sum, na.rm = TRUE) %>%
-        filter(!is.na(sector), !is.na(fuel)) %>%
-        mutate_all( funs( replace(., is.na(.), 0))) %>%
-        mutate_if(is.numeric, funs(. * CONV_GG_TG)) ->
-        L103.ghg_tg_USA_an_Sepa_F_2005
-    }
+      L103.ghg_tg_USA_an_Sepa_F_2005
 
     # Map FAO production to EPA sectors and aggregate
     # Select region - US and year - 2005

--- a/R/zchunk_L103.ghg_an_USA_S_T_Y.R
+++ b/R/zchunk_L103.ghg_an_USA_S_T_Y.R
@@ -44,7 +44,7 @@ module_emissions_L103.ghg_an_USA_S_T_Y <- function(command, ...) {
     # EPA data contains estimates for aggregate and disaggregate sectors. There should be NAs when
     # mapping to GCAM sector and fuel to avoid double counting those totals.
 
-    # Note summarize ignoring NA to ensure correct poltry emissions estimate,
+    # Note summarize ignoring NA to ensure correct poultry emissions estimate,
     # methane emissions for poultry are relatively small
     # compared to other animals, but non-zero
     EPA_FCCC_AG_2005 %>%


### PR DESCRIPTION
Having to do with not ignoring NA values when summing poultry CH4 emissions factor thus resulting in zero emissions factor.

Directly related data products change:
```
1. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 4. Rows in y but not x: 4. 
L103.ghg_tgmt_USA_an_Sepa_F_2005.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 77798, 77758, 77694, 77486, 77212, 77210, 77204, 77202, 77196, 77194, 77188[...]. Rows in y but not x: 77574, 77440, 77438, 77376, 77204, 77194, 77188, 77180, 77172, 77162, 77154[...]. 
L113.ghg_tg_R_an_C_Sys_Fd_Yh.csv doesn't match

3. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 4430, 3404, 3286, 5806, 2242, 3403, 5898, 5890, 5884, 5874, 5844[...]. Rows in y but not x: 5900, 5884, 5882, 5874, 5854, 5846, 5844, 5838, 5830, 5798, 5796[...]. 
L211.AnEmissions.csv doesn't match
```

Statistical differences:
[diff_L103.ghg_an_USA_S_T_Y.txt](https://github.com/JGCRI/gcamdata/files/2143637/diff_L103.ghg_an_USA_S_T_Y.txt)
