### PR TITLE
OLDNEW for L100.Population_downscale_ctry

### DIFF
--- a/R/zchunk_L100.Population_downscale_ctry.R
+++ b/R/zchunk_L100.Population_downscale_ctry.R
@@ -51,18 +51,9 @@ module_socioeconomics_L100.Population_downscale_ctry <- function(command, ...) {
     # Second, estimate population values prior to 1950 for countries in aggregate regions. This is what we want: pop_country_t = (pop_aggregate_t / pop_aggregate_1950) * pop_country_1950
     # Generate a scalar for population in each aggregate region in 1950 (to generate the population ratios)
     agg_ratio <- pop_thous_ctry_reg %>%
-      select(Maddison_ctry, year, pop)
-    # OLD DATA SYSTEM BEHAVIOR: There is one additional aggregate region (Eritrea & Ethiopia) that wasn't included in the downscaling. New behavior includes it.
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      agg_ratio <- filter(agg_ratio, year <= min(socioeconomics.UN_HISTORICAL_YEARS) &
-                            Maddison_ctry %in% c("Total Former USSR", "Czechoslovakia", "Yugoslavia"))  # Only want years prior to 1951 for the three regions
-      # Because we changed the mapping file, adding in Eritrea & Ethiopia, for old behavior we need to strip these back out from pop_thous_ctry_reg
-      pop_thous_ctry_reg <- mutate(pop_thous_ctry_reg, Downscale_from = gsub("Eritrea and Ethiopia", NA, Downscale_from))
-    } else {
-      agg_ratio <- filter(agg_ratio, year <=  min(socioeconomics.UN_HISTORICAL_YEARS) &
-                            Maddison_ctry %in% c("Czechoslovakia", "Eritrea and Ethiopia", "Total Former USSR", "Yugoslavia")) # Only want years prior to 1951 for the four aggregate regions
-    }
-    agg_ratio <- agg_ratio %>%
+      select(Maddison_ctry, year, pop) %>%
+      filter(year <=  min(socioeconomics.UN_HISTORICAL_YEARS) &
+             Maddison_ctry %in% c("Czechoslovakia", "Eritrea and Ethiopia", "Total Former USSR", "Yugoslavia")) %>% # Only want years prior to 1951 for the four aggregate regions
       group_by(Maddison_ctry) %>%  # Group to perform action on each aggregate region individually
       mutate(ratio = pop / pop[year == min(socioeconomics.UN_HISTORICAL_YEARS)]) %>%  # Create ratio of population in prior years to population in 1950
       rename(Downscale_from = Maddison_ctry) %>%  # Will match each country in the region to this ratio


### PR DESCRIPTION
Having to do with missing "Eritrea and Ethiopia" in the old ds population mapping file.

This affects a number of downstream data products mostly having to do with land cover:
```
1. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 10580, 10579, 10571, 10562, 10556, 10549, 10545, 10536, 10534, 10533, 10532[...]. Rows in y but not x: 10575, 10572, 10569, 10556, 10550, 10549, 10548, 10546, 10532, 10522, 10510[...]. 
L100.Pop_thous_ctry_Yh.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 1428, 1427, 1382, 1381, 1336, 1335, 1293, 1292, 1289, 1199, 1198[...]. Rows in y but not x: 1382, 1293, 1291, 1290, 1289, 1243, 1197, 1151, 1109, 1108, 1107[...]. 
L101.Pop_thous_R_Yh.csv doesn't match

3. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 1861, 509, 238, 295, 169, 299, 286, 1912, 1859, 160, 1900[...]. Rows in y but not x: 1915, 1912, 1903, 1894, 1891, 1882, 1880, 1871, 1870, 1865, 1863[...]. 
L123.LC_bm2_R_MgdFor_Yh_GLU.csv doesn't match

4. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 15089, 14679, 14633, 14632, 14540, 14402, 14399, 14311, 14310, 14307, 14265[...]. Rows in y but not x: 14679, 14678, 14633, 14629, 14540, 14495, 14403, 14399, 14310, 14265, 14264[...]. 
L124.LC_bm2_R_UnMgdFor_Yh_GLU_adj.csv doesn't match

5. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 43934, 56949, 75968, 77531, 56953, 43980, 44394, 75979, 56309, 50236, 53962[...]. Rows in y but not x: 77589, 77585, 77583, 77582, 77577, 77573, 77571, 77567, 77561, 77556, 77549[...]. 
L125.LC_bm2_R_LT_Yh_GLU.csv doesn't match

6. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 4146, 6109, 6101, 6088, 6085, 6067, 6053, 6046, 6045, 6035, 6032[...]. Rows in y but not x: 6109, 6085, 6067, 6066, 6064, 6063, 6053, 6045, 6029, 6025, 6022[...]. 
L2231.LN1_HistUnmgdAllocation_prot.csv doesn't match

7. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 1432, 1919, 1913, 1907, 1903, 1901, 1897, 1891, 1886, 1883, 1871[...]. Rows in y but not x: 1919, 1918, 1915, 1913, 1912, 1907, 1903, 1897, 1894, 1891, 1886[...]. 
L2231.LN3_HistMgdAllocation_noncrop.csv doesn't match

8. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 6035, 6025, 6018, 5989, 5944, 5924, 5923, 5919, 5909, 5905, 5926[...]. Rows in y but not x: 6024, 6004, 5965, 5944, 5930, 5927, 5926, 5924, 5923, 5910, 5909[...]. 
L2231.LN3_HistUnmgdAllocation_noprot.csv doesn't match

9. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 6168, 4222, 6108, 6101, 5997, 6088, 6087, 6081, 6046, 6045, 6039[...]. Rows in y but not x: 6109, 6108, 6088, 6084, 6053, 6052, 6035, 6029, 6025, 6021, 6018[...]. 
L2231.LN3_HistUnmgdAllocation.csv doesn't match
```

Note, the reason why even more files did not change (the `dstrace("L101.Pop_thous_R_Yh", "downstream")` is endless) is because this only affects historical years <= 1900.

Statistical differences:
[diff_L100.Population_downscale_ctry.txt](https://github.com/JGCRI/gcamdata/files/2145837/diff_L100.Population_downscale_ctry.txt)