### PR TITLE
OLDNEW for L270.limits / Negative Emissions Budgets

### DIFF
--- a/R/zchunk_L270.limits.R
+++ b/R/zchunk_L270.limits.R
@@ -10,7 +10,7 @@
 #' @param ... other optional parameters, depending on command
 #' @return Depends on \code{command}: either a vector of required inputs,
 #' a vector of output names, or (if \code{command} is "MAKE") all
-#' the generated outputs: \code{L270.CreditOutput}, \code{L270.CreditInput_elec}, \code{L270.CreditInput_feedstocks}, \code{L270.CreditMkt}, \code{L270.CTaxInput}, \code{L270.NegEmissFinalDemand}, \code{L270.NegEmissFinalDemand_SPA}, \code{L270.NegEmissBudgetMaxPrice}, \code{paste0( "L270.NegEmissBudget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), c("spa1", "spa23", "spa4", "spa5")) )}. The corresponding file in the
+#' the generated outputs: \code{L270.CreditOutput}, \code{L270.CreditInput_elec}, \code{L270.CreditInput_feedstocks}, \code{L270.CreditMkt}, \code{L270.CTaxInput}, \code{L270.NegEmissFinalDemand}, \code{L270.NegEmissFinalDemand_SPA}, \code{L270.NegEmissBudgetMaxPrice}, \code{paste0( "L270.NegEmissBudget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), paste0("spa", 1:5))) )}. The corresponding file in the
 #' original data system was \code{L270.limits.R} (energy level2).
 #' @details Generate GCAM policy constraints which enforce limits to liquid feedstocks
 #' and the amount of subsidies given for net negative emissions.
@@ -38,7 +38,7 @@ module_energy_L270.limits <- function(command, ...) {
              # TODO: might just be easier to keep the scenarios in a single
              # table here and split when making XMLs but to match the old
              # data system we will split here
-             paste0( "L270.NegEmissBudget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), c("spa1", "spa23", "spa4", "spa5")) )))
+             paste0( "L270.NegEmissBudget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), paste0("spa", 1:5)) )))
   } else if(command == driver.MAKE) {
 
     value <- subsector <- supplysector <- year <- GCAM_region_ID <- sector.name <-
@@ -147,21 +147,7 @@ module_energy_L270.limits <- function(command, ...) {
     # split out SSPs so that we can generate SPA policies
     # NOTE: SPA policies *must* be regional no matter the value of NEG_EMISS_MARKT_GLOBAL
     L270.NegEmissBudget %>%
-      filter(grepl('^SSP\\d', scenario)) ->
-      L270.NegEmissBudget_SPA
-    # While it is true SSP 2 and 3 share policy assumptions (SPA) they do not
-    # share GDPs.  The data contained in L270.NegEmissBudget is GDP * policy assumption
-    # thus we should in fact keep them seperate.  Further, we are currently not considering
-    # scenario specific policies although it may make sense to do so in the future to fit in
-    # with SSP story lines.
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      L270.NegEmissBudget_SPA %>%
-        # SSP 2 and 3 share SPA
-        filter(scenario != "SSP3") %>%
-        mutate(scenario = if_else(scenario == "SSP2", "SSP23", scenario)) ->
-        L270.NegEmissBudget_SPA
-    }
-    L270.NegEmissBudget_SPA %>%
+      filter(grepl('^SSP\\d', scenario)) %>%
       mutate(scenario = sub('SSP', 'spa', scenario)) ->
       L270.NegEmissBudget_SPA
 

--- a/R/zchunk_batch_negative_emissions_budget_xml.R
+++ b/R/zchunk_batch_negative_emissions_budget_xml.R
@@ -1,12 +1,12 @@
 #' module_energy_batch_negative_emissions_budget_xml
 #'
-#' Construct XML data structure for \code{paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5)), ".xml")}.
+#' Construct XML data structure for \code{paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5)), paste0("spa", 1:5), ".xml")}.
 #'
 #' @param command API command to execute
 #' @param ... other optional parameters, depending on command
 #' @return Depends on \code{command}: either a vector of required inputs,
 #' a vector of output names, or (if \code{command} is "MAKE") all
-#' the generated outputs: \code{paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), c("spa1", "spa23", "spa4", "spa5")), ".xml")}. The corresponding file in the
+#' the generated outputs: \code{paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), paste0("spa", 1:5)), ".xml")}. The corresponding file in the
 #' original data system was \code{L270.limits.R} (energy XML).
 module_energy_batch_negative_emissions_budget_xml <- function(command, ...) {
   if(command == driver.DECLARE_INPUTS) {
@@ -14,9 +14,9 @@ module_energy_batch_negative_emissions_budget_xml <- function(command, ...) {
               "L270.NegEmissFinalDemand",
               "L270.NegEmissFinalDemand_SPA",
               "L270.NegEmissBudgetMaxPrice",
-              paste0("L270.NegEmissBudget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), c("spa1", "spa23", "spa4", "spa5"))) ))
+              paste0("L270.NegEmissBudget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), paste0("spa", 1:5))) ))
   } else if(command == driver.DECLARE_OUTPUTS) {
-    xml_files = paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), c("spa1", "spa23", "spa4", "spa5")), ".xml")
+    xml_files = paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), paste0("spa", 1:5)), ".xml")
     names(xml_files) <- rep("XML", length(xml_files))
     return(xml_files)
   } else if(command == driver.MAKE) {
@@ -33,8 +33,8 @@ module_energy_batch_negative_emissions_budget_xml <- function(command, ...) {
 
     # ===================================================
 
-    scenarios <- c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), c("spa1", "spa23", "spa4", "spa5"))
-    xml_files = paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), c("spa1", "spa23", "spa4", "spa5")), ".xml")
+    scenarios <- c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), paste0("spa", 1:5))
+    xml_files = paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), paste0("spa", 1:5)), ".xml")
 
     # Produce outputs
     ret_data <- c()

--- a/man/module_energy_L270.limits.Rd
+++ b/man/module_energy_L270.limits.Rd
@@ -14,7 +14,7 @@ module_energy_L270.limits(command, ...)
 \value{
 Depends on \code{command}: either a vector of required inputs,
 a vector of output names, or (if \code{command} is "MAKE") all
-the generated outputs: \code{L270.CreditOutput}, \code{L270.CreditInput_elec}, \code{L270.CreditInput_feedstocks}, \code{L270.CreditMkt}, \code{L270.CTaxInput}, \code{L270.NegEmissFinalDemand}, \code{L270.NegEmissFinalDemand_SPA}, \code{L270.NegEmissBudgetMaxPrice}, \code{paste0( "L270.NegEmissBudget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), c("spa1", "spa23", "spa4", "spa5")) )}. The corresponding file in the
+the generated outputs: \code{L270.CreditOutput}, \code{L270.CreditInput_elec}, \code{L270.CreditInput_feedstocks}, \code{L270.CreditMkt}, \code{L270.CTaxInput}, \code{L270.NegEmissFinalDemand}, \code{L270.NegEmissFinalDemand_SPA}, \code{L270.NegEmissBudgetMaxPrice}, \code{paste0( "L270.NegEmissBudget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), paste0("spa", 1:5))) )}. The corresponding file in the
 original data system was \code{L270.limits.R} (energy level2).
 }
 \description{

--- a/man/module_energy_batch_negative_emissions_budget_xml.Rd
+++ b/man/module_energy_batch_negative_emissions_budget_xml.Rd
@@ -14,9 +14,9 @@ module_energy_batch_negative_emissions_budget_xml(command, ...)
 \value{
 Depends on \code{command}: either a vector of required inputs,
 a vector of output names, or (if \code{command} is "MAKE") all
-the generated outputs: \code{paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), c("spa1", "spa23", "spa4", "spa5")), ".xml")}. The corresponding file in the
+the generated outputs: \code{paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5), paste0("spa", 1:5)), ".xml")}. The corresponding file in the
 original data system was \code{L270.limits.R} (energy XML).
 }
 \description{
-Construct XML data structure for \code{paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5)), ".xml")}.
+Construct XML data structure for \code{paste0( "negative_emissions_budget_", c("GCAM3", paste0("SSP", 1:5), paste0("gSSP", 1:5)), paste0("spa", 1:5), ".xml")}.
 }


### PR DESCRIPTION
splitting apart spa23 so 2 and 3 each have their own budgets.  This is
because while they should share policy assumptions the actual GDPs are
different which factors into the budget.

Note this will require a GCAM_DATA_MAP update at some point but I see a conflict 'a brewin so I've put it off for now until we omnibus.

This should remove the `L270.NegEmissBudget_spa23` data product and add `L270.NegEmissBudget_spa2` and `L270.NegEmissBudget_spa3`