### PR TITLE
OLDNEW for LA143.HDDCDD

### DIFF
--- a/R/zchunk_LA143.HDDCDD.R
+++ b/R/zchunk_LA143.HDDCDD.R
@@ -83,27 +83,15 @@ module_energy_LA143.HDDCDD <- function(command, ...) {
              value = if_else(value < 0, 0, value)
       )
 
-    if(OLD_DATA_SYSTEM_BEHAVIOR) {
-      # Add in country iso
-      L143.HDDCDD_scen_ctry_Y <- HDDCDD_data %>%
-        # Drop file name
-        select(-file) %>%
-        # Filter only useful years
-        filter(year %in% c(HISTORICAL_YEARS, FUTURE_YEARS)) %>%
-        # Drop Cote d'Ivoire--this is a mistake in old data system
-        filter(country != "Cote d'Ivoire") %>%
-        left_join_error_no_match(GIS_ctry, by = "country")
-    } else {
-      # Add in country iso
-      L143.HDDCDD_scen_ctry_Y <- HDDCDD_data %>%
-        # Drop file name
-        select(-file) %>%
-        # Filter only useful years
-        filter(year %in% c(HISTORICAL_YEARS, FUTURE_YEARS)) %>%
-        # Remove apostrophe in Cote d'Ivoire and add in country iso by country name
-        mutate(country = if_else(country == "Cote d'Ivoire", "Cote dIvoire", country)) %>%
-        left_join_error_no_match(GIS_ctry, by = 'country')
-    }
+    # Add in country iso
+    L143.HDDCDD_scen_ctry_Y <- HDDCDD_data %>%
+      # Drop file name
+      select(-file) %>%
+      # Filter only useful years
+      filter(year %in% c(HISTORICAL_YEARS, FUTURE_YEARS)) %>%
+      # Remove apostrophe in Cote d'Ivoire and add in country iso by country name
+      mutate(country = if_else(country == "Cote d'Ivoire", "Cote dIvoire", country)) %>%
+      left_join_error_no_match(GIS_ctry, by = 'country')
 
     # Serbia and Montenegro are currently combined. Copy to separated countries, assigning the same HDD and CDD to each
     if("scg" %in% L143.HDDCDD_scen_ctry_Y$iso) {


### PR DESCRIPTION
having to do with:
* Not dropping Cote 'dIvoire
* New method for weighted mean DD using population as weights

This changes a surprising number of data products:
```
1. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 2409, 2410, 2902. Rows in y but not x: 2902, 2410, 2409. 
L101.in_EJ_R_en_Si_F_Yh.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 311855, 54526, 54517, 33022, 14086, 26375, 59649, 54332, 54529, 14287, 59838[...]. Rows in y but not x: 311855, 59838, 59649, 54529, 54526, 54517, 54332, 53208, 40919, 33022, 14287[...]. 
L111.nonghg_tg_R_en_S_F_Yh.csv doesn't match

3. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 18539, 9704. Rows in y but not x: 9704, 18539. 
L112.ghg_tg_R_en_S_F_Yh.csv doesn't match

4. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 20241, 19811, 924, 1364, 3072, 19807, 20236, 933, 19810, 19805, 1353[...]. Rows in y but not x: 20236, 19811, 19810, 19807, 19805, 3072, 1364, 1353, 935, 933, 924[...]. 
L141.hfc_ef_R_cooling_Yh.csv doesn't match

5. Failure: matches old data system output (@test_oldnew.R#99) -----------------
dim(olddata) not identical to dim(newdata).
1/2 mismatches
[1] 103008 - 103240 == -232
Dimensions are not the same for L143.HDDCDD_scen_ctry_Y.csv

6. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Different number of rows
L143.HDDCDD_scen_ctry_Y.csv doesn't match

7. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 2357, 2665, 2392, 2608, 2362, 2615, 2571, 2356, 2602, 2364, 2638[...]. Rows in y but not x: 2663, 2661, 2656, 2655, 2654, 2652, 2649, 2648, 2646, 2645, 2643[...]. 
L143.HDDCDD_scen_R_Y.csv doesn't match

8. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 315, 27, 262, 109, 246, 95, 342, 265, 42, 249, 108[...]. Rows in y but not x: 348, 346, 345, 344, 343, 339, 338, 335, 333, 330, 327[...]. 
L143.HDDCDD_scen_RG3_Y.csv doesn't match

9. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 5653. Rows in y but not x: 5653. 
L144.base_service_EJ_serv.csv doesn't match

10. Failure: matches old data system output (@test_oldnew.R#112) ---------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 24796, 5111, 5119, 5084, 5060, 5045, 5075, 5112. Rows in y but not x: 24796, 5111, 5084, 5075, 5045, 5112, 5060, 5119. 
L144.in_EJ_R_bld_serv_F_Yh.csv doesn't match

11. Failure: matches old data system output (@test_oldnew.R#112) ---------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 608, 334. Rows in y but not x: 334, 608. 
L241.hfc_future.csv doesn't match

12. Failure: matches old data system output (@test_oldnew.R#112) ---------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 355, 414, 354, 418, 368, 410, 353, 372, 369, 370, 367[...]. Rows in y but not x: 418, 415, 414, 412, 410, 407, 405, 403, 402, 401, 400[...]. 
L244.HDDCDD_A2_CCSM3x.csv doesn't match

13. Failure: matches old data system output (@test_oldnew.R#112) ---------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 409, 415, 398, 400, 408, 362, 372, 373, 364, 405, 411[...]. Rows in y but not x: 418, 417, 416, 415, 412, 411, 410, 408, 407, 406, 405[...]. 
L244.HDDCDD_B1_CCSM3x.csv doesn't match

14. Failure: matches old data system output (@test_oldnew.R#112) ---------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 69, 5. Rows in y but not x: 69, 5. 
L244.Intgains_scalar.csv doesn't match

15. Failure: matches old data system output (@test_oldnew.R#112) ---------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 506, 507, 505. Rows in y but not x: 505, 506, 507. 
L244.StubTechCalInput_bld.csv doesn't match
```

It changes some base service values in buildings but not by much.  It cascaded into emissions from there:
[diff_LA143.HDDCDD.txt](https://github.com/JGCRI/gcamdata/files/2146701/diff_LA143.HDDCDD.txt)
