### PR TITLE
Fix a regression of proposal 244

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -240,6 +240,12 @@ aglu.AVG_WOOD_DENSITY_KGM3 <- 500 # In kg per m3
 # Carbon content of wood is about 50 percent across species
 aglu.AVG_WOOD_DENSITY_KGCM3 <- 250 # In kg carbon per m3
 
+# Carbon content adjustments from unmanaged to managed
+aglu.CVEG_MULT_UNMGDFOR_MGDFOR <- 0.5
+aglu.CSOIL_MULT_UNMGDFOR_MGDFOR <- 0.87      #source: Guo and Gifford 2002
+aglu.CVEG_MULT_UNMGDPAST_MGDPAST <- 0.5
+aglu.CSOIL_MULT_UNMGDPAST_MGDPAST <- 0.9     # stay conservative here b/c no data source
+
 # Average Agriculture Density kg/m^3 for mass conversion
 # Source: http://www.engineeringtoolbox.com/wood-density-d_40.html
 aglu.AVG_AG_DENSITY <- 1

--- a/R/constants.R
+++ b/R/constants.R
@@ -241,8 +241,14 @@ aglu.AVG_WOOD_DENSITY_KGM3 <- 500 # In kg per m3
 aglu.AVG_WOOD_DENSITY_KGCM3 <- 250 # In kg carbon per m3
 
 # Carbon content adjustments from unmanaged to managed
+# conversion factor from unmanaged forest to managed forest, where the former is
+# understood to be forest not in logging rotation, and the latter is forest in
+# logging rotation. The average vegetation biomass of the logged forest is assumed
+# to be 50% of that of the unlogged forest (integrated over the rotation period).
+# Using 50% under the assumption that the veg biomass of the logged forest over the
+# rotation period can be approximated by a triangle.
 aglu.CVEG_MULT_UNMGDFOR_MGDFOR <- 0.5
-aglu.CSOIL_MULT_UNMGDFOR_MGDFOR <- 0.87      #source: Guo and Gifford 2002
+aglu.CSOIL_MULT_UNMGDFOR_MGDFOR <- 0.87      #source: Guo and Gifford 2002; https://doi.org/10.1046/j.1354-1013.2002.00486.x
 aglu.CVEG_MULT_UNMGDPAST_MGDPAST <- 0.5
 aglu.CSOIL_MULT_UNMGDPAST_MGDPAST <- 0.9     # stay conservative here b/c no data source
 

--- a/R/module-helpers.R
+++ b/R/module-helpers.R
@@ -381,19 +381,18 @@ add_carbon_info <- function( data, carbon_info_table, matchvars = c("region", "G
 #' @return The original table with carbon density adjusted for the managed land types
 reduce_mgd_carbon <- function( data, LTfor = "Forest", LTpast = "Pasture") {
 
-  hist.veg.carbon.density <- Cveg_Mult_UnmgdPast_MgdPast <- veg.carbon.density <-
-    hist.soil.carbon.density <- Csoil_Mult_UnmgdPast_MgdPast <- soil.carbon.density <-
-    Cveg_Mult_UnmgdFor_MgdFor <- Csoil_Mult_UnmgdFor_MgdFor <- NULL # silence package check notes
+  Land_Type <- hist.veg.carbon.density <- veg.carbon.density <-
+    hist.soil.carbon.density <- soil.carbon.density <- NULL # silence package check notes
 
   data %>%
-    mutate(hist.veg.carbon.density = if_else("Land_Type" == LTpast, hist.veg.carbon.density * Cveg_Mult_UnmgdPast_MgdPast, hist.veg.carbon.density)) %>%
-    mutate(veg.carbon.density = if_else("Land_Type" == LTpast, veg.carbon.density * Cveg_Mult_UnmgdPast_MgdPast, veg.carbon.density)) %>%
-    mutate(hist.soil.carbon.density = if_else("Land_Type" == LTpast, hist.soil.carbon.density * Csoil_Mult_UnmgdPast_MgdPast, hist.soil.carbon.density)) %>%
-    mutate(soil.carbon.density = if_else("Land_Type" == LTpast, soil.carbon.density * Csoil_Mult_UnmgdPast_MgdPast, soil.carbon.density)) %>%
-    mutate(hist.veg.carbon.density = if_else("Land_Type" == LTfor, hist.veg.carbon.density * Cveg_Mult_UnmgdFor_MgdFor, hist.veg.carbon.density)) %>%
-    mutate(veg.carbon.density = if_else("Land_Type" == LTfor, veg.carbon.density * Cveg_Mult_UnmgdFor_MgdFor, veg.carbon.density)) %>%
-    mutate(hist.soil.carbon.density = if_else("Land_Type" == LTfor, hist.soil.carbon.density * Csoil_Mult_UnmgdFor_MgdFor, hist.soil.carbon.density)) %>%
-    mutate(soil.carbon.density = if_else("Land_Type" == LTfor, soil.carbon.density * Csoil_Mult_UnmgdFor_MgdFor, soil.carbon.density))
+    mutate(hist.veg.carbon.density = if_else(Land_Type == LTpast, hist.veg.carbon.density * aglu.CVEG_MULT_UNMGDPAST_MGDPAST, hist.veg.carbon.density)) %>%
+    mutate(veg.carbon.density = if_else(Land_Type == LTpast, veg.carbon.density * aglu.CVEG_MULT_UNMGDPAST_MGDPAST, veg.carbon.density)) %>%
+    mutate(hist.soil.carbon.density = if_else(Land_Type == LTpast, hist.soil.carbon.density * aglu.CSOIL_MULT_UNMGDPAST_MGDPAST, hist.soil.carbon.density)) %>%
+    mutate(soil.carbon.density = if_else(Land_Type == LTpast, soil.carbon.density * aglu.CSOIL_MULT_UNMGDPAST_MGDPAST, soil.carbon.density)) %>%
+    mutate(hist.veg.carbon.density = if_else(Land_Type == LTfor, hist.veg.carbon.density * aglu.CVEG_MULT_UNMGDFOR_MGDFOR, hist.veg.carbon.density)) %>%
+    mutate(veg.carbon.density = if_else(Land_Type == LTfor, veg.carbon.density * aglu.CVEG_MULT_UNMGDFOR_MGDFOR, veg.carbon.density)) %>%
+    mutate(hist.soil.carbon.density = if_else(Land_Type == LTfor, hist.soil.carbon.density * aglu.CSOIL_MULT_UNMGDFOR_MGDFOR, hist.soil.carbon.density)) %>%
+    mutate(soil.carbon.density = if_else(Land_Type == LTfor, soil.carbon.density * aglu.CSOIL_MULT_UNMGDFOR_MGDFOR, soil.carbon.density))
 }
 
 

--- a/R/zchunk_L222.land_input_2.R
+++ b/R/zchunk_L222.land_input_2.R
@@ -256,6 +256,7 @@ module_aglu_L222.land_input_2 <- function(command, ...) {
       left_join_error_no_match(GCAMLandLeaf_CdensityLT, by = c("Land_Type" = "LandLeaf")) %>%
       rename(Cdensity_LT = Land_Type.y) %>%
       add_carbon_info(carbon_info_table = L121.CarbonContent_kgm2_R_LT_GLU) %>%
+      reduce_mgd_carbon() %>%
       select(LEVEL2_DATA_NAMES[["LN2_MgdCarbon"]]) ->
       L222.LN2_MgdCarbon
 

--- a/R/zchunk_L2231.land_input_3_irr.R
+++ b/R/zchunk_L2231.land_input_3_irr.R
@@ -215,6 +215,7 @@ module_aglu_L2231.land_input_3_irr <- function(command, ...) {
       left_join_error_no_match(select(GCAMLandLeaf_CdensityLT, Land_Type, LandLeaf), by = c("Land_Type" = "LandLeaf")) %>%
       rename(Cdensity_LT = Land_Type.y) %>%
       add_carbon_info(carbon_info_table = L121.CarbonContent_kgm2_R_LT_GLU) %>%
+      reduce_mgd_carbon() %>%
       select(LEVEL2_DATA_NAMES[["LN3_MgdCarbon"]]) ->
       L223.LN3_MgdCarbon_noncrop
 


### PR DESCRIPTION
Reduce carbon contents of managed forest and pasture where the carbon content was not being properly reduced from the unmanged values.  The regression came somewhere in the merge of GCAM 4.4 changes into GCAM 5.  This closes #875.

Only direct data products are affected:
```
1. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 377, 376, 374, 372, 369, 368, 366, 365, 363, 362, 361[...]. Rows in y but not x: 378, 377, 375, 373, 371, 370, 369, 368, 366, 364, 363[...]. 
L222.LN2_MgdCarbon.csv doesn't match

2. Failure: matches old data system output (@test_oldnew.R#112) ----------------
round_df(olddata) not equivalent to round_df(newdata).
Rows in x but not y: 336, 335, 331, 330, 328, 327, 326, 325, 324, 323, 321[...]. Rows in y but not x: 336, 335, 332, 328, 326, 324, 318, 317, 311, 309, 304[...]. 
L2231.LN3_MgdCarbon_noncrop.csv doesn't match
```

And they are reduced exactly as we expected:
[diff_reduce_mgd_carbon.txt](https://github.com/JGCRI/gcamdata/files/2147634/diff_reduce_mgd_carbon.txt)
