### PR TITLE
gcamdata-China-v1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     testthat (>= 1.0.2),
     R.utils (>= 2.6.0),
     gcamdata.compdata
-Remotes: github::JGCRI/gcamdata.compdata
+Remotes: github::JGCRI/gcamdata.compdata#16
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1


### PR DESCRIPTION
**NOTE**: this branch is based on gcamdata v1.0, created for gcam-China dsr. Not merge to master any time soon (replace the gcamdata-China branch). 