### PR TITLE
Update gcamdata.compdata pointer for usa-emis-v1.0 branch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Suggests:
     testthat (>= 1.0.2),
     R.utils (>= 2.6.0),
     gcamdata.compdata
-Remotes: github::JGCRI/gcamdata.compdata
+Remotes: github::JGCRI/gcamdata.compdata#19
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1


### PR DESCRIPTION
Update DESCRIPTION to point to the rebased version off of v1: JGCRI/gcamdata.compdata#19